### PR TITLE
feat: handle context as a part of campaign's title and add validation callback before displaying the message (SDKCF-2870)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,6 @@ application_id=com.rakuten.tech.mobile.inappmessaging
 # ---------------------------------- AndroidX flags ----------------------------------------------
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableD8=true
 # ---------------------------------- Robolectric flags -------------------------------------------
 android.enableUnitTestBinaryResources=true

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -41,7 +41,6 @@ android {
 
   buildTypes {
     release {
-      useProguard true
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -33,9 +33,10 @@ internal class InApp(
     }
 
     // ------------------------------------Public APIs-----------------------------------------------
-    override var onVerifyContext: (contexts: List<String>, campaignTitle: String) -> Boolean
-        get() = displayManager.verifyCampaignContextsCallback
-        set(value) { displayManager.verifyCampaignContextsCallback = value }
+    override var onVerifyContext: (contexts: List<String>, campaignTitle: String) -> Boolean = { _, _ -> Boolean
+        // Allow all contexts by default
+        true
+    }
 
     override fun registerPreference(userInfoProvider: UserInfoProvider) {
         AccountRepository.instance().userInfoProvider = userInfoProvider

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -33,6 +33,10 @@ internal class InApp(
     }
 
     // ------------------------------------Public APIs-----------------------------------------------
+    override var onVerifyContext: (contexts: List<String>, campaignTitle: String) -> Boolean
+        get() = displayManager.verifyCampaignContextsCallback
+        set(value) { displayManager.verifyCampaignContextsCallback = value }
+
     override fun registerPreference(userInfoProvider: UserInfoProvider) {
         AccountRepository.instance().userInfoProvider = userInfoProvider
         AccountRepository.instance().updateUserInfo()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -18,6 +18,12 @@ import org.jetbrains.annotations.Nullable
 @Suppress("UnnecessaryAbstractClass")
 abstract class InAppMessaging internal constructor() {
     /**
+     * This callback is called just before showing a message of campaign that has registered contexts.
+     * Return `false` to prevent the message from displaying.
+     */
+    abstract var onVerifyContext: (contexts: List<String>, campaignTitle: String) -> Boolean
+
+    /**
      * This method registers provider containing user information [userInfoProvider], like RAE Token and Uer ID.
      */
     abstract fun registerPreference(@NotNull userInfoProvider: UserInfoProvider)
@@ -108,6 +114,8 @@ abstract class InAppMessaging internal constructor() {
 
     @Suppress("EmptyFunctionBlock")
     internal class NotInitializedInAppMessaging : InAppMessaging() {
+        override var onVerifyContext: (contexts: List<String>, campaignTitle: String) -> Boolean = { _, _ -> true }
+
         override fun registerPreference(userInfoProvider: UserInfoProvider) {}
 
         override fun registerMessageDisplayActivity(activity: Activity) {}

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
@@ -37,4 +37,6 @@ internal interface Message {
      * This method returns max impressions.
      */
     fun getMaxImpressions(): Int?
+
+    fun getContexts(): List<String>
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignData.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignData.kt
@@ -32,4 +32,10 @@ internal data class CampaignData(
     override fun isTest(): Boolean = isTest
 
     override fun getMaxImpressions(): Int = maxImpressions
+
+    override fun getContexts(): List<String> {
+        val regex = Regex("\\[(.*?)\\]")
+        val matches = regex.findAll(messagePayload.title ?: "")
+        return matches.map { it.groupValues[1] }.toList()
+    }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManager.kt
@@ -11,6 +11,9 @@ import timber.log.Timber
  * Display manager, which controls displaying message, or removing message from the screen.
  */
 internal interface DisplayManager {
+
+    var verifyCampaignContextsCallback: (contexts: List<String>, campaignTitle: String) -> Boolean
+
     /**
      * Thread safe method to display message on UI thread.
      */
@@ -31,7 +34,13 @@ internal interface DisplayManager {
 
     private class DisplayManagerImpl : DisplayManager {
 
+        override var verifyCampaignContextsCallback: (contexts: List<String>, campaignTitle: String) -> Boolean = {
+            // Allow all contexts by default
+            _, _ -> true
+        }
+
         override fun displayMessage() {
+            DisplayMessageJobIntentService.verifyCampaignContextsCallback = verifyCampaignContextsCallback
             DisplayMessageJobIntentService.enqueueWork(Intent())
         }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManager.kt
@@ -12,8 +12,6 @@ import timber.log.Timber
  */
 internal interface DisplayManager {
 
-    var verifyCampaignContextsCallback: (contexts: List<String>, campaignTitle: String) -> Boolean
-
     /**
      * Thread safe method to display message on UI thread.
      */
@@ -34,13 +32,7 @@ internal interface DisplayManager {
 
     private class DisplayManagerImpl : DisplayManager {
 
-        override var verifyCampaignContextsCallback: (contexts: List<String>, campaignTitle: String) -> Boolean = {
-            // Allow all contexts by default
-            _, _ -> true
-        }
-
         override fun displayMessage() {
-            DisplayMessageJobIntentService.verifyCampaignContextsCallback = verifyCampaignContextsCallback
             DisplayMessageJobIntentService.enqueueWork(Intent())
         }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
@@ -91,7 +91,9 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
             return true
         }
 
-        val isConfirmed = InAppMessaging.instance().onVerifyContext(campaignContexts, message.getMessagePayload()?.title ?: "")
+        val isConfirmed = InAppMessaging.instance().onVerifyContext(
+                campaignContexts,
+                message.getMessagePayload()?.title ?: "")
         if (!isConfirmed) {
             // Message display aborted by the host app
             Timber.tag(TAG).d("message display cancelled by the host app")

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.withContext
  */
 internal class InAppMessageViewListener(
     val message: Message?,
-    private val messagCoroutine: MessageActionsCoroutine = MessageActionsCoroutine(),
+    private val messageCoroutine: MessageActionsCoroutine = MessageActionsCoroutine(),
     private val displayManager: DisplayManager = DisplayManager.instance(),
     private val buildChecker: BuildVersionChecker = BuildVersionChecker.instance()
 ) :
@@ -73,7 +73,7 @@ internal class InAppMessageViewListener(
             CoroutineScope(Dispatchers.Main).launch {
                 displayManager.removeMessage(InAppMessaging.instance().getRegisteredActivity())
                 withContext(Dispatchers.Default) {
-                    val result = messagCoroutine.executeTask(message, view.id, isOptOutChecked)
+                    val result = messageCoroutine.executeTask(message, view.id, isOptOutChecked)
                     if (result) {
                         displayManager.displayMessage()
                     }
@@ -89,7 +89,7 @@ internal class InAppMessageViewListener(
                 displayManager.removeMessage(InAppMessaging.instance().getRegisteredActivity())
                 withContext(Dispatchers.Default) {
                     // no need to handle result since no event should be triggered by back button
-                    messagCoroutine.executeTask(message, MessageActionsCoroutine.BACK_BUTTON, isOptOutChecked)
+                    messageCoroutine.executeTask(message, MessageActionsCoroutine.BACK_BUTTON, isOptOutChecked)
                 }
             }
             return true

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -6,11 +6,13 @@ import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
+import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.AppStartEvent
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.config.ConfigResponseData
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import org.amshove.kluent.*
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +35,11 @@ class InAppMessagingSpec : BaseTest() {
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
+    }
+
+    @After
+    fun tearDown() {
+        Mockito.validateMockitoUsage()
     }
 
     @Test
@@ -149,4 +156,19 @@ class InAppMessagingSpec : BaseTest() {
             fail("should not throw exception")
         }
     }
+
+//    @Test
+//    fun `should call provided callback when verifying campaign's contexts`() {
+//        When calling configResponseData.enabled itReturns true
+//        ConfigResponseRepository.instance().addConfigResponse(configResponseData)
+//
+//        val callback = mock<(List<String>, String) -> Boolean>()
+//        val inApp = InApp(ApplicationProvider.getApplicationContext(), false, displayManager)
+//        inApp.registerMessageDisplayActivity(activity)
+//        inApp.onVerifyContext = callback
+//
+//        Mockito.verify(callback, Mockito.times(1)).invoke(listOf(), "")
+//
+//        ConfigResponseRepository.resetInstance()
+//    }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -6,13 +6,11 @@ import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
-import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.AppStartEvent
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.config.ConfigResponseData
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import org.amshove.kluent.*
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,11 +33,6 @@ class InAppMessagingSpec : BaseTest() {
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
-    }
-
-    @After
-    fun tearDown() {
-        Mockito.validateMockitoUsage()
     }
 
     @Test
@@ -156,19 +149,4 @@ class InAppMessagingSpec : BaseTest() {
             fail("should not throw exception")
         }
     }
-
-//    @Test
-//    fun `should call provided callback when verifying campaign's contexts`() {
-//        When calling configResponseData.enabled itReturns true
-//        ConfigResponseRepository.instance().addConfigResponse(configResponseData)
-//
-//        val callback = mock<(List<String>, String) -> Boolean>()
-//        val inApp = InApp(ApplicationProvider.getApplicationContext(), false, displayManager)
-//        inApp.registerMessageDisplayActivity(activity)
-//        inApp.onVerifyContext = callback
-//
-//        Mockito.verify(callback, Mockito.times(1)).invoke(listOf(), "")
-//
-//        ConfigResponseRepository.resetInstance()
-//    }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/InvalidTestMessage.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/InvalidTestMessage.kt
@@ -15,4 +15,6 @@ internal class InvalidTestMessage : Message {
     override fun isTest(): Boolean = false
 
     override fun getMaxImpressions(): Int = 0
+
+    override fun getContexts(): List<String> = listOf()
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/ValidTestMessage.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/ValidTestMessage.kt
@@ -22,6 +22,8 @@ internal class ValidTestMessage(var id: String = DEFAULT_CAMPAIGN_ID, private va
 
     override fun getMaxImpressions(): Int = 1
 
+    override fun getContexts(): List<String> = listOf()
+
     @Suppress("ComplexCondition")
     override fun equals(other: Any?): Boolean {
         val otherObject = other as Message

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
@@ -216,8 +216,55 @@ class MessageMixerResponseSpec(private val testname: String, private val actual:
                 campaignTrigger.triggerAttributes[0].operator)
     }
 
+    private fun generateDummyCampaign(id: String, title: String): CampaignData {
+        val messagePayload = MessagePayload(null, null, null, null, null, null, null, null, title, null)
+        return CampaignData(messagePayload, 1, listOf(), id, false, 1)
+    }
+
     @Test
     fun `should be correct value after parsing`() {
         actual shouldEqual expected
+    }
+
+    @Test
+    fun `should return empty array if there are no contexts when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "title")
+        campaign.getContexts() shouldEqual listOf()
+    }
+
+    @Test
+    fun `should properly read context if there's nothing beside it when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "[ctx]")
+        campaign.getContexts() shouldEqual listOf("ctx")
+    }
+
+    @Test
+    fun `should properly read one context when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "[ctx] title")
+        campaign.getContexts() shouldEqual listOf("ctx")
+    }
+
+    @Test
+    fun `should properly read multiple contexts when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "[ctx1] [ctx2][ctx3] title")
+        campaign.getContexts() shouldEqual listOf("ctx1", "ctx2", "ctx3")
+    }
+
+    @Test
+    fun `should properly read multiple contexts separated with characters when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "[ctx A]~~[ctx B]ab ab[ctx C]")
+        campaign.getContexts() shouldEqual listOf("ctx A", "ctx B", "ctx C")
+    }
+
+    @Test
+    fun `should ignore invalid contexts when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "[ctx] [ctxbad title")
+        campaign.getContexts() shouldEqual listOf("ctx")
+    }
+
+    @Test
+    fun `should properly read context even if there are invalid ones when calling getContexts()`() {
+        val campaign = generateDummyCampaign("id", "ctxbad] title [ctx]")
+        campaign.getContexts() shouldEqual listOf("ctx")
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -12,7 +12,6 @@ import com.facebook.datasource.DataSource
 import com.facebook.soloader.SoLoader
 import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
@@ -104,122 +103,131 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         displayMessageJobIntentService!!.onHandleWork(intent!!)
     }
 
-// TODO: Fix tests crash when calling verifyCampaignContextsCallback
-//
-//    @Test
-//    fun `should call verifyCampaignContextsCallback for non-test campaign with contexts`() {
-//        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
-//                Settings.Secure.ANDROID_ID, "test_device_id")
-//        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
-//        InAppMessaging.instance().registerMessageDisplayActivity(activity)
-//
-//        val message = Mockito.mock(Message::class.java)
-//        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
-//        val callback = mock<(List<String>, String) -> Boolean>()
-//        DisplayMessageJobIntentService.verifyCampaignContextsCallback = callback
-//
-//        When calling message.getCampaignId() itReturns "1"
-//        When calling message.isTest() itReturns false
-//        When calling message.getMaxImpressions() itReturns 1
-//        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
-//                MessagePayload::class.java)
-//        When calling message.getContexts() itReturns listOf("ctx")
-//        When calling mockMessageManager.getNextDisplayMessage() itReturns message
-//        When calling activity
-//                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-//        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
-//        displayMessageJobIntentService!!.onHandleWork(intent!!)
-//
-//        Mockito.verify(callback, Mockito.times(1)).invoke(listOf("ctx"), "[ctx] Campaign Title")
-//    }
-//
-//    @Test
-//    fun `should not call verifyCampaignContextsCallback for non-test campaign without contexts`() {
-//        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
-//                Settings.Secure.ANDROID_ID, "test_device_id")
-//        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
-//        InAppMessaging.instance().registerMessageDisplayActivity(activity)
-//
-//        val message = Mockito.mock(Message::class.java)
-//        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
-//        val callback = mock<(List<String>, String) -> Boolean>()
-//        DisplayMessageJobIntentService.verifyCampaignContextsCallback = callback
-//
-//        When calling message.getCampaignId() itReturns "1"
-//        When calling message.isTest() itReturns false
-//        When calling message.getMaxImpressions() itReturns 1
-//        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
-//                MessagePayload::class.java)
-//        When calling message.getContexts() itReturns listOf()
-//        When calling mockMessageManager.getNextDisplayMessage() itReturns message
-//        When calling activity
-//                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-//        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
-//        displayMessageJobIntentService!!.onHandleWork(intent!!)
-//
-//        Mockito.verify(callback, Mockito.times(0)).invoke(any(), any())
-//    }
-//
-//    @Test
-//    fun `should not call verifyCampaignContextsCallback for test campaign with contexts`() {
-//        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
-//                Settings.Secure.ANDROID_ID, "test_device_id")
-//        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
-//        InAppMessaging.instance().registerMessageDisplayActivity(activity)
-//
-//        val message = Mockito.mock(Message::class.java)
-//        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
-//        val callback = mock<(List<String>, String) -> Boolean>()
-//        DisplayMessageJobIntentService.verifyCampaignContextsCallback = callback
-//
-//        When calling message.getCampaignId() itReturns "1"
-//        When calling message.isTest() itReturns true
-//        When calling message.getMaxImpressions() itReturns 1
-//        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
-//                MessagePayload::class.java)
-//        When calling message.getContexts() itReturns listOf("ctx")
-//        When calling mockMessageManager.getNextDisplayMessage() itReturns message
-//        When calling activity
-//                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-//        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
-//        displayMessageJobIntentService!!.onHandleWork(intent!!)
-//
-//        Mockito.verify(callback, Mockito.times(0)).invoke(any(), any())
-//    }
-//
-//    @Test
-//    fun `should call verifyCampaignContextsCallback with proper parameters`() {
-//        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
-//                Settings.Secure.ANDROID_ID, "test_device_id")
-//        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
-//        InAppMessaging.instance().registerMessageDisplayActivity(activity)
-//
-//        val message = Mockito.mock(Message::class.java)
-//        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
-//        val callback = mock<(List<String>, String) -> Boolean>()
-//        DisplayMessageJobIntentService.verifyCampaignContextsCallback = callback
-//
-//        When calling message.getCampaignId() itReturns "1"
-//        When calling message.isTest() itReturns false
-//        When calling message.getMaxImpressions() itReturns 1
-//        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
-//                MessagePayload::class.java)
-//        When calling message.getContexts() itReturns listOf("ctx")
-//        When calling mockMessageManager.getNextDisplayMessage() itReturns message
-//        When calling activity
-//                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-//        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
-//        displayMessageJobIntentService!!.onHandleWork(intent!!)
-//
-//        argumentCaptor<List<String>>().apply {
-//            Mockito.verify(callback).invoke(capture(), any())
-//            firstValue shouldEqual listOf("ctx")
-//        }
-//        argumentCaptor<String>().apply {
-//            Mockito.verify(callback).invoke(any(), capture())
-//            firstValue shouldBeEqualTo "[ctx] Campaign Title"
-//        }
-//    }
+    @Test
+    fun `should call onVerifyContext for non-test campaign with contexts`() {
+        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID, "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
+        InAppMessaging.instance().registerMessageDisplayActivity(activity)
+
+        val message = Mockito.mock(Message::class.java)
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
+
+        val callback = Mockito.mock(InAppMessaging.instance().onVerifyContext.javaClass)
+        When calling callback.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = callback
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        When calling activity
+                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
+        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(callback, Mockito.times(1))
+                .invoke(listOf("ctx"), "Campaign Title")
+    }
+
+    @Test
+    fun `should not call onVerifyContext for non-test campaign without contexts`() {
+        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID, "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
+        InAppMessaging.instance().registerMessageDisplayActivity(activity)
+
+        val message = Mockito.mock(Message::class.java)
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
+
+        val callback = Mockito.mock(InAppMessaging.instance().onVerifyContext.javaClass)
+        When calling callback.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = callback
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf()
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        When calling activity
+                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
+        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(callback, Mockito.times(0))
+                .invoke(any(), any())
+    }
+
+    @Test
+    fun `should not call onVerifyContext for test campaign with contexts`() {
+        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID, "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
+        InAppMessaging.instance().registerMessageDisplayActivity(activity)
+
+        val message = Mockito.mock(Message::class.java)
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
+
+        val callback = Mockito.mock(InAppMessaging.instance().onVerifyContext.javaClass)
+        When calling callback.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = callback
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns true
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        When calling activity
+                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
+        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(callback, Mockito.times(0))
+                .invoke(any(), any())
+    }
+
+    @Test
+    fun `should call onVerifyContext with proper parameters`() {
+        Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID, "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
+        InAppMessaging.instance().registerMessageDisplayActivity(activity)
+
+        val message = Mockito.mock(Message::class.java)
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
+
+        val callback = Mockito.mock(InAppMessaging.instance().onVerifyContext.javaClass)
+        When calling callback.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = callback
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        When calling activity
+                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
+        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        argumentCaptor<List<String>>().apply {
+            Mockito.verify(callback).invoke(capture(), any())
+            firstValue shouldEqual listOf("ctx")
+        }
+        argumentCaptor<String>().apply {
+            Mockito.verify(callback).invoke(any(), capture())
+            firstValue shouldBeEqualTo "Campaign Title"
+        }
+    }
 
     companion object {
         private const val MESSAGE_PAYLOAD = """
@@ -246,7 +254,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
                     "cropType":2,
                     "imageUrl":"https://sample.image.url/test.jpg"
                 },
-                "title":"[ctx] Campaign Title",
+                "title":"Campaign Title",
                 "titleColor":"#000000"
             }
         """
@@ -273,7 +281,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
                 "resource":{
                     "cropType":2
                 },
-                "title":"[ctx] Campaign Title",
+                "title":"Campaign Title",
                 "titleColor":"#000000"
             }
         """


### PR DESCRIPTION
# Description
Solution no. 2 for issue https://github.com/rakutentech/ios-inappmessaging/issues/10
I couldn't get some unit tests to work. I'd appreciate any help on that because I've used all my ideas...
Tested on Android simulator with real campaign data.

## Links
https://github.com/rakutentech/ios-inappmessaging/issues/10
SDKCF-2871

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [ ] I ran `./gradlew check` without errors