### PR TITLE
fix: fix cyclical call when onVerifyContext returned false, update user guide

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -232,6 +232,21 @@ Custom event class:
 InAppMessaging.instance().logEvent(CustomEvent("search").addAttribute("keyword", "book").addAttribute("number_of_keyword", 1))
 ```
 
+### #9 Campaign's context (advanced feature)
+A context can be defined as the text inside "[]" within an IAM portal "Campaign Name" e.g. the campaign name is "[ctx1] title" so the context is "ctx1".
+Multiple contexts are supported.
+In order to handle defined contexts in the code an optional callback is called before a message is displayed:
+
+```kotlin
+InAppMessaging.instance().onVerifyContext = { contexts: List<String>, campaignTitle: String -> Boolean
+    if /* check your condition e.g. are you on the correct screen to display this message? */ {
+        true // campaign message will be displayed
+    } else {
+        false // campaign message won't be displayed
+    }
+}
+```
+
 ## <a name="troubleshooting"></a> Trouble Shooting
 `proguard.ParseException`
 

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -12,6 +12,7 @@ The In-App Messaging module enables applications to receive notification, which 
 * [Requirements](#requirements)
 * [Getting Started](#getting-started)
 * [SDK Integration](#integration)
+* [Advanced Features](#advanced)
 * [FAQ](#faq)
 * [Documentation and Useful Links](#see-also)
 * [Change Log](#nchangelog)
@@ -232,7 +233,10 @@ Custom event class:
 InAppMessaging.instance().logEvent(CustomEvent("search").addAttribute("keyword", "book").addAttribute("number_of_keyword", 1))
 ```
 
-### #9 Campaign's context (advanced feature)
+## <a name="advanced"></a> Advanced Features
+
+### #1 Campaign's context
+Contexts are used to add more control on when campaigns are displayed.
 A context can be defined as the text inside "[]" within an IAM portal "Campaign Name" e.g. the campaign name is "[ctx1] title" so the context is "ctx1".
 Multiple contexts are supported.
 In order to handle defined contexts in the code an optional callback is called before a message is displayed:

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -30,7 +30,7 @@ internal interface MessageReadinessManager {
      */
     @WorkerThread
     @Suppress("LongMethod", "ReturnCount")
-    fun getNextDisplayMessage(): Message?
+    fun getNextDisplayMessage(ignored: List<Message> = listOf()): Message?
 
     /**
      * This method returns a DisplayPermissionRequest object.
@@ -56,8 +56,9 @@ internal interface MessageReadinessManager {
     private class MessageReadinessManagerImpl : MessageReadinessManager {
         @WorkerThread
         @Suppress("LongMethod", "ReturnCount")
-        override fun getNextDisplayMessage(): Message? {
-            val messageList: List<Message> = ReadyForDisplayMessageRepository.instance().getAllMessagesCopy()
+        override fun getNextDisplayMessage(ignored: List<Message>): Message? {
+            var messageList: List<Message> = ReadyForDisplayMessageRepository.instance().getAllMessagesCopy()
+            messageList.subtract(ignored)
             for (message in messageList) {
                 Timber.tag(TAG).d("checking permission for message: %s", message.getCampaignId())
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
@@ -23,6 +23,7 @@ import timber.log.Timber
 internal class DisplayMessageJobIntentService : JobIntentService() {
     @VisibleForTesting
     var messageReadinessManager = MessageReadinessManager.instance()
+    private var ignoredMessages: List<Message> = listOf()
     /**
      * This method starts displaying message runnable.
      */
@@ -37,7 +38,7 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
      */
     private fun prepareNextMessage() {
         // Retrieving the next ready message, and its display permission been checked.
-        val message: Message = messageReadinessManager.getNextDisplayMessage() ?: return
+        val message: Message = messageReadinessManager.getNextDisplayMessage(ignoredMessages) ?: return
         val hostActivity = InAppMessaging.instance().getRegisteredActivity()
         val imageUrl = message.getMessagePayload()?.resource?.imageUrl
         if (hostActivity != null) {
@@ -97,6 +98,7 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
         if (!isConfirmed) {
             // Message display aborted by the host app
             Timber.tag(TAG).d("message display cancelled by the host app")
+            ignoredMessages += message
             prepareNextMessage()
         }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping
 import android.os.Build
 import com.google.gson.Gson
 import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldHaveSize
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
@@ -216,7 +217,7 @@ class MessageMixerResponseSpec(private val testname: String, private val actual:
                 campaignTrigger.triggerAttributes[0].operator)
     }
 
-    private fun generateDummyCampaign(id: String, title: String): CampaignData {
+    private fun generateDummyCampaign(id: String, title: String?): CampaignData {
         val messagePayload = MessagePayload(null, null, null, null, null, null, null, null, title, null)
         return CampaignData(messagePayload, 1, listOf(), id, false, 1)
     }
@@ -229,7 +230,7 @@ class MessageMixerResponseSpec(private val testname: String, private val actual:
     @Test
     fun `should return empty array if there are no contexts when calling getContexts()`() {
         val campaign = generateDummyCampaign("id", "title")
-        campaign.getContexts() shouldEqual listOf()
+        campaign.getContexts() shouldHaveSize 0
     }
 
     @Test
@@ -266,5 +267,17 @@ class MessageMixerResponseSpec(private val testname: String, private val actual:
     fun `should properly read context even if there are invalid ones when calling getContexts()`() {
         val campaign = generateDummyCampaign("id", "ctxbad] title [ctx]")
         campaign.getContexts() shouldEqual listOf("ctx")
+    }
+
+    @Test
+    fun `should not return any context when title is empty`() {
+        val campaign = generateDummyCampaign("id", "")
+        campaign.getContexts() shouldHaveSize 0
+    }
+
+    @Test
+    fun `should not return any context when title is null`() {
+        val campaign = generateDummyCampaign("id", null)
+        campaign.getContexts() shouldHaveSize 0
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Build
 import android.provider.Settings
 import android.view.LayoutInflater
+import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.facebook.datasource.DataSource
@@ -24,6 +25,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.validateMockitoUsage
 import org.mockito.MockitoAnnotations
@@ -52,15 +54,14 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         MockitoAnnotations.initMocks(this)
         serviceController = Robolectric.buildService(DisplayMessageJobIntentService::class.java)
         displayMessageJobIntentService = serviceController?.bind()?.create()?.get()
+        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
         WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        When calling activity.layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
 
         Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
                 Settings.Secure.ANDROID_ID, "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
-
-        When calling onVerifyContexts.invoke(any(), any()) itReturns true
-        InAppMessaging.instance().onVerifyContext = onVerifyContexts
     }
 
     @After
@@ -84,8 +85,6 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling message.getMaxImpressions() itReturns 10
         When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD.trimIndent(),
                 MessagePayload::class.java)
-        When calling activity
-                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
         displayMessageJobIntentService!!.onHandleWork(intent!!)
     }
 
@@ -97,14 +96,15 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling message.getCampaignId() itReturns "1"
         When calling message.isTest() itReturns true
         When calling message.getMaxImpressions() itReturns 10
-        When calling activity
-                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
         displayMessageJobIntentService!!.onHandleWork(intent!!)
     }
 
     @Test
     fun `should call onVerifyContext for non-test campaign with contexts`() {
         val message = Mockito.mock(Message::class.java)
+
+        When calling onVerifyContexts.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = onVerifyContexts
 
         When calling message.getCampaignId() itReturns "1"
         When calling message.isTest() itReturns false
@@ -113,9 +113,6 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
                 MessagePayload::class.java)
         When calling message.getContexts() itReturns listOf("ctx")
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
-        When calling activity
-                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         Mockito.verify(onVerifyContexts, Mockito.times(1))
@@ -126,6 +123,9 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
     fun `should not call onVerifyContext for non-test campaign without contexts`() {
         val message = Mockito.mock(Message::class.java)
 
+        When calling onVerifyContexts.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = onVerifyContexts
+
         When calling message.getCampaignId() itReturns "1"
         When calling message.isTest() itReturns false
         When calling message.getMaxImpressions() itReturns 1
@@ -133,9 +133,6 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
                 MessagePayload::class.java)
         When calling message.getContexts() itReturns listOf()
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
-        When calling activity
-                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         Mockito.verify(onVerifyContexts, Mockito.times(0))
@@ -146,6 +143,9 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
     fun `should not call onVerifyContext for test campaign with contexts`() {
         val message = Mockito.mock(Message::class.java)
 
+        When calling onVerifyContexts.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = onVerifyContexts
+
         When calling message.getCampaignId() itReturns "1"
         When calling message.isTest() itReturns true
         When calling message.getMaxImpressions() itReturns 1
@@ -153,9 +153,6 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
                 MessagePayload::class.java)
         When calling message.getContexts() itReturns listOf("ctx")
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
-        When calling activity
-                .layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         Mockito.verify(onVerifyContexts, Mockito.times(0))
@@ -167,6 +164,9 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
     fun `should call onVerifyContext with proper parameters`() {
         val message = Mockito.mock(Message::class.java)
 
+        When calling onVerifyContexts.invoke(any(), any()) itReturns true
+        InAppMessaging.instance().onVerifyContext = onVerifyContexts
+
         When calling message.getCampaignId() itReturns "1"
         When calling message.isTest() itReturns false
         When calling message.getMaxImpressions() itReturns 1
@@ -174,8 +174,6 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
                 MessagePayload::class.java)
         When calling message.getContexts() itReturns listOf("ctx")
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
-        When calling activity.layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
-        displayMessageJobIntentService!!.messageReadinessManager = mockMessageManager
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         argumentCaptor<List<String>>().apply {
@@ -186,6 +184,91 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
             Mockito.verify(onVerifyContexts).invoke(any(), capture())
             firstValue shouldBeEqualTo "Campaign Title"
         }
+    }
+
+    @Test
+    fun `should call getMessagePayload again when message's context was rejected`() {
+        val message = Mockito.mock(Message::class.java)
+
+        When calling onVerifyContexts.invoke(any(), any()) itReturns false
+        InAppMessaging.instance().onVerifyContext = onVerifyContexts
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(mockMessageManager, Mockito.times(2)).getNextDisplayMessage(any())
+    }
+
+    @Test
+    fun `should call getMessagePayload with ignored message if that message's context was rejected`() {
+        val message = Mockito.mock(Message::class.java)
+
+        When calling onVerifyContexts.invoke(any(), any()) itReturns false
+        InAppMessaging.instance().onVerifyContext = onVerifyContexts
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        argumentCaptor<List<Message>>().apply {
+            Mockito.verify(mockMessageManager, Mockito.times(2)).getNextDisplayMessage(capture())
+            secondValue shouldEqual listOf(message)
+        }
+    }
+
+    @Test
+    fun `should display campaign if onVerifyContext was not set (default value)`() {
+        val message = Mockito.mock(Message::class.java)
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(activity, Mockito.times(1))
+                .findViewById<View?>(ArgumentMatchers.anyInt())
+    }
+
+    @Test
+    fun `should not display campaign if activity is not registered`() {
+        InAppMessaging.instance().unregisterMessageDisplayActivity()
+        val message = Mockito.mock(Message::class.java)
+
+        When calling message.getCampaignId() itReturns "1"
+        When calling message.isTest() itReturns false
+        When calling message.getMaxImpressions() itReturns 1
+        When calling message.getMessagePayload() itReturns Gson().fromJson(MESSAGE_PAYLOAD_NO_URL.trimIndent(),
+                MessagePayload::class.java)
+        When calling message.getContexts() itReturns listOf("ctx")
+        When calling mockMessageManager.getNextDisplayMessage() itReturns message
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(activity, Mockito.times(0))
+                .findViewById<View?>(ArgumentMatchers.anyInt())
+    }
+
+    @Test
+    fun `should not display campaign if payload is null`() {
+        When calling mockMessageManager.getNextDisplayMessage() itReturns null
+        displayMessageJobIntentService!!.onHandleWork(intent!!)
+
+        Mockito.verify(activity, Mockito.times(0))
+                .findViewById<View?>(ArgumentMatchers.anyInt())
     }
 
     companion object {


### PR DESCRIPTION
# Description
When campaign was rejected it was still marked as ready to display so when `prepareNextMessage()` was called after `onVerifyContext()` returned false the repository kept returning the same message over and over creating a cycle.
Rejected campaigns ara now stored in a list.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [ ] I ran `./gradlew check` without errors