### PR TITLE
fix: fix messageList.subtract() call

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -58,8 +58,10 @@ internal interface MessageReadinessManager {
         @Suppress("LongMethod", "ReturnCount")
         override fun getNextDisplayMessage(ignored: List<Message>): Message? {
             var messageList: List<Message> = ReadyForDisplayMessageRepository.instance().getAllMessagesCopy()
-            messageList.subtract(ignored)
             for (message in messageList) {
+                if (ignored.contains(message)) {
+                    continue
+                }
                 Timber.tag(TAG).d("checking permission for message: %s", message.getCampaignId())
 
                 // First, check if this message should be displayed.

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
@@ -85,6 +85,15 @@ class MessageReadinessManagerSpec : BaseTest() {
     }
 
     @Test
+    fun `should ignore test message`() {
+        val messageList = ArrayList<Message>()
+        messageList.add(ValidTestMessage("1", false))
+        messageList.add(testMessage)
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        MessageReadinessManager.instance().getNextDisplayMessage(listOf(testMessage)).shouldBeNull()
+    }
+
+    @Test
     fun `should get display permission request with all attributes`() {
         val message = ValidTestMessage()
         val request = MessageReadinessManager.instance().getDisplayPermissionRequest(message)


### PR DESCRIPTION
# Description
subtract() method doesn't modify existing list - it's returning new object (a Set) instead.
It was easier to use a condition instead of subtracting 2 lists.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I ran `./gradlew check` without errors