### PR TITLE
fix: update LocalDisplayedMessageRepository after rejecting campaign's context

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -30,7 +30,7 @@ internal interface MessageReadinessManager {
      */
     @WorkerThread
     @Suppress("LongMethod", "ReturnCount")
-    fun getNextDisplayMessage(ignored: List<Message> = listOf()): Message?
+    fun getNextDisplayMessage(): Message?
 
     /**
      * This method returns a DisplayPermissionRequest object.
@@ -56,12 +56,9 @@ internal interface MessageReadinessManager {
     private class MessageReadinessManagerImpl : MessageReadinessManager {
         @WorkerThread
         @Suppress("LongMethod", "ReturnCount")
-        override fun getNextDisplayMessage(ignored: List<Message>): Message? {
+        override fun getNextDisplayMessage(): Message? {
             var messageList: List<Message> = ReadyForDisplayMessageRepository.instance().getAllMessagesCopy()
             for (message in messageList) {
-                if (ignored.contains(message)) {
-                    continue
-                }
                 Timber.tag(TAG).d("checking permission for message: %s", message.getCampaignId())
 
                 // First, check if this message should be displayed.

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
@@ -85,15 +85,6 @@ class MessageReadinessManagerSpec : BaseTest() {
     }
 
     @Test
-    fun `should ignore test message`() {
-        val messageList = ArrayList<Message>()
-        messageList.add(ValidTestMessage("1", false))
-        messageList.add(testMessage)
-        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
-        MessageReadinessManager.instance().getNextDisplayMessage(listOf(testMessage)).shouldBeNull()
-    }
-
-    @Test
     fun `should get display permission request with all attributes`() {
         val message = ValidTestMessage()
         val request = MessageReadinessManager.instance().getDisplayPermissionRequest(message)


### PR DESCRIPTION
# Description
This prevents from stacking campaigns (events) when campaign's context was rejected and later accepted.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I ran `./gradlew check` without errors