### PR TITLE
feat: [SDKCF-3199] add close campaign API and refactor some test codes

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -218,6 +218,17 @@ InAppMessaging.instance().onVerifyContext = { contexts: List<String>, campaignTi
 }
 ```
 
+### <a name="close-campaign"></a> #2 Close campaign API
+There are cases that apps need to manually close the campaigns without user interaction.
+
+An example is when a different user logs-in and the currently displayed campaign does not target the new user.
+
+It is possible that the new user did not close the campaign (tapping the 'X' button) when logging in. The app can force-close the campaign by calling the `closeMessage()` API.
+
+```kotlin
+InAppMessaging.instance().closeMessage()
+```
+
 ## <a name="troubleshooting"></a> Troubleshooting
 <details>
 <summary>proguard.ParseException (click to expand)</summary>
@@ -273,6 +284,9 @@ Documents targeting Product Managers:
 + In-App Messaging Dashboard Sign Up(page is coming soon.)
 
 ## <a name="changelog"></a> Changelog
+
+### 2.3.0 (in-progress)
+* SDKCF-3199: Add `closeMessage` API for programmatically closing campaigns without user action.
 
 ### 2.2.0 (2020-11-10)
 * SDKCF-2870: Allow host app to control if a campaign should be displayed in the current screen (using [contexts](#context))

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -219,7 +219,7 @@ InAppMessaging.instance().onVerifyContext = { contexts: List<String>, campaignTi
 ```
 
 ### <a name="close-campaign"></a> #2 Close campaign API
-There are cases that apps need to manually close the campaigns without user interaction.
+There may be cases where apps need to manually close the campaigns without user interaction.
 
 An example is when a different user logs-in and the currently displayed campaign does not target the new user.
 

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -229,6 +229,8 @@ It is possible that the new user did not close the campaign (tapping the 'X' but
 InAppMessaging.instance().closeMessage()
 ```
 
+**<font color="red">Note:</font> Calling this API will not increment the campaign's impression (i.e not counted as displayed).**
+
 ## <a name="troubleshooting"></a> Troubleshooting
 <details>
 <summary>proguard.ParseException (click to expand)</summary>

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -68,11 +68,14 @@ internal class InApp(
 
     // ------------------------------------Library Internal APIs-------------------------------------
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    override fun getRegisteredActivity(): Activity? =
-            if (activityWeakReference != null) activityWeakReference!!.get() else null
+    override fun getRegisteredActivity() = if (activityWeakReference != null) activityWeakReference!!.get() else null
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    override fun getHostAppContext(): Context? = context
+    override fun getHostAppContext() = context
+
+    override fun closeMessage() {
+        displayManager.removeMessage(getRegisteredActivity())
+    }
 
     companion object {
         private const val TAG = "IAM_InAppMessaging"

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -75,8 +75,8 @@ abstract class InAppMessaging internal constructor() {
     internal abstract fun getHostAppContext(): Context?
 
     /**
-     * This methods manually closes the currently displayed message.
-     * This method should be called when app needs to force-close the displayed message without user action.
+     * Close the currently displayed message.
+     * This should be called when app needs to force-close the displayed message without user action.
      * Calling this method will not increment the campaign impression.
      */
     abstract fun closeMessage()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -74,6 +74,13 @@ abstract class InAppMessaging internal constructor() {
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     internal abstract fun getHostAppContext(): Context?
 
+    /**
+     * This methods manually closes the currently displayed message.
+     * This method should be called when app needs to force-close the displayed message without user action.
+     * Calling this method will not increment the campaign impression.
+     */
+    abstract fun closeMessage()
+
     companion object {
         private var instance: InAppMessaging = NotInitializedInAppMessaging()
 
@@ -130,5 +137,7 @@ abstract class InAppMessaging internal constructor() {
         override fun getRegisteredActivity(): Activity? = null
 
         override fun getHostAppContext(): Context? = null
+
+        override fun closeMessage() {}
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
@@ -75,7 +75,7 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
      * This method displays message on UI thread.
      */
     private fun displayMessage(message: Message, hostActivity: Activity) {
-        if (verifyContexts(message) == false) {
+        if (!verifyContexts(message)) {
             // Message display aborted by the host app
             Timber.tag(TAG).d("message display cancelled by the host app")
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
@@ -21,7 +21,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.mockito.MockitoAnnotations
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -181,12 +180,11 @@ internal class MessageActionsCoroutineSpec(val testName: String, val resourceId:
                 }"""
     }
 
-    private var message = Gson().fromJson(CAMPAIGN_DATA.trimIndent(), CampaignData::class.java)
-    private var activity = Mockito.mock(Activity::class.java)
+    private val message = Gson().fromJson(CAMPAIGN_DATA.trimIndent(), CampaignData::class.java)
+    private val activity = Mockito.mock(Activity::class.java)
 
     @Before
     fun setup() {
-        MockitoAnnotations.initMocks(this)
         When calling activity.packageManager itReturns ApplicationProvider
                 .getApplicationContext<Context>().packageManager
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManagerSpec.kt
@@ -7,24 +7,17 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import org.amshove.kluent.When
 import org.amshove.kluent.calling
 import org.amshove.kluent.itReturns
-import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.MockitoAnnotations
 
 /**
  * Test class for DisplayManager.
  */
 class DisplayManagerSpec : BaseTest() {
 
-    private var activity = Mockito.mock(Activity::class.java)
-    private var viewGroup = Mockito.mock(ViewGroup::class.java)
-    private var parentViewGroup = Mockito.mock(ViewGroup::class.java)
-
-    @Before
-    fun setup() {
-        MockitoAnnotations.initMocks(this)
-    }
+    private val activity = Mockito.mock(Activity::class.java)
+    private val viewGroup = Mockito.mock(ViewGroup::class.java)
+    private val parentViewGroup = Mockito.mock(ViewGroup::class.java)
 
     @Test
     fun `should display message enqueue without exceptions`() {
@@ -33,10 +26,10 @@ class DisplayManagerSpec : BaseTest() {
 
     @Test
     fun `should remove message from host activity`() {
-        Mockito.`when`<Any?>(activity!!.findViewById(R.id.in_app_message_base_view)).thenReturn(viewGroup)
-        When calling viewGroup!!.parent itReturns parentViewGroup
+        When calling activity.findViewById<ViewGroup>(R.id.in_app_message_base_view) itReturns viewGroup
+        When calling viewGroup.parent itReturns parentViewGroup
         DisplayManager.instance().removeMessage(activity)
-        Mockito.verify(parentViewGroup)!!.removeView(viewGroup)
+        Mockito.verify(parentViewGroup).removeView(viewGroup)
     }
 
     @Test

--- a/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
+++ b/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
@@ -77,6 +77,9 @@ class MainActivityFragment : Fragment(), View.OnClickListener {
                 .setView(contentView)
                 .setTitle(R.string.dialog_title_user)
                 .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                    if (application.provider.userId != userId.text.toString()) {
+                        InAppMessaging.instance().closeMessage()
+                    }
                     application.provider.userId = userId.text.toString()
                     application.provider.raeToken = raeToken.text.toString()
                     application.provider.rakutenId = rakutenId.text.toString()

--- a/test/src/main/res/layout/fragment_main.xml
+++ b/test/src/main/res/layout/fragment_main.xml
@@ -16,6 +16,12 @@
     android:text="@string/launch_second_activity"/>
 
   <Button
+    android:id="@+id/change_user"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/change_user"/>
+
+  <Button
     android:id="@+id/launch_successful"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -56,11 +62,5 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:text="@string/custom_event_newuser"/>
-
-  <Button
-    android:id="@+id/change_user"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:text="@string/change_user"/>
 
 </LinearLayout>


### PR DESCRIPTION
# Description
This new API is for programmatically closing campaigns without user interaction.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors