### PR TITLE
feat: [SDKCF-3266] add clearing for campaign to display queue

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -229,6 +229,13 @@ It is possible that the new user did not close the campaign (tapping the 'X' but
 InAppMessaging.instance().closeMessage()
 ```
 
+An optional parameter, `clearQueuedCampaigns`, can be set to `true` (`false` by default) which will additionally remove all campaigns that were queued to be displayed.
+
+```kotlin
+InAppMessaging.instance().closeMessage(true)
+```
+
+
 **<font color="red">Note:</font> Calling this API will not increment the campaign's impression (i.e not counted as displayed).**
 
 ## <a name="troubleshooting"></a> Troubleshooting
@@ -288,7 +295,7 @@ Documents targeting Product Managers:
 ## <a name="changelog"></a> Changelog
 
 ### 2.3.0 (in-progress)
-* SDKCF-3199: Add `closeMessage` API for programmatically closing campaigns without user action.
+* SDKCF-3199: Add [`closeMessage` API](#close-campaign) for programmatically closing campaigns without user action.
 
 ### 2.2.0 (2020-11-10)
 * SDKCF-2870: Allow host app to control if a campaign should be displayed in the current screen (using [contexts](#context))

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -91,7 +91,7 @@ internal class InApp(
         val id = displayManager.removeMessage(getRegisteredActivity())
 
         if (clearQueuedCampaigns) {
-            ReadyForDisplayMessageRepository.instance().clearMessages(clearQueuedCampaigns)
+            ReadyForDisplayMessageRepository.instance().clearMessages(true)
         } else if (id != null) {
             ReadyForDisplayMessageRepository.instance().removeMessage(id as String, true)
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.inappmessaging.runtime
 import android.app.Activity
 import android.content.Context
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
@@ -11,6 +12,9 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.SessionManager
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.ref.WeakReference
 
@@ -76,6 +80,14 @@ internal class InApp(
     override fun getHostAppContext() = context
 
     override fun closeMessage(clearQueuedCampaigns: Boolean) {
+        CoroutineScope(Dispatchers.Main).launch {
+            // called inside main dispatcher to make sure that it is always called in UI thread
+            removeMessage(clearQueuedCampaigns)
+        }
+    }
+
+    @VisibleForTesting
+    internal fun removeMessage(clearQueuedCampaigns: Boolean) {
         val id = displayManager.removeMessage(getRegisteredActivity())
 
         if (clearQueuedCampaigns) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -6,7 +6,6 @@ import androidx.annotation.RestrictTo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
@@ -75,12 +74,13 @@ internal class InApp(
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     override fun getHostAppContext() = context
 
-    override fun closeMessage() {
+    override fun closeMessage(clearQueuedCampaigns: Boolean) {
         val id = displayManager.removeMessage(getRegisteredActivity())
 
-        if (id != null) {
-            // Remove message from ReadyForDisplayMessageRepository.
-            val message = ReadyForDisplayMessageRepository.instance().removeMessage(id as String)
+        if (clearQueuedCampaigns) {
+            ReadyForDisplayMessageRepository.instance().clearMessages(clearQueuedCampaigns)
+        } else if (id != null) {
+            ReadyForDisplayMessageRepository.instance().removeMessage(id as String, true)
         }
     }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -78,8 +78,10 @@ abstract class InAppMessaging internal constructor() {
      * Close the currently displayed message.
      * This should be called when app needs to force-close the displayed message without user action.
      * Calling this method will not increment the campaign impression.
+     * @param clearQueuedCampaigns An optional parameter, when set to true (false by default), will additionally
+     * remove all campaigns that were queued to be displayed.
      */
-    abstract fun closeMessage()
+    abstract fun closeMessage(clearQueuedCampaigns: Boolean = false)
 
     companion object {
         private var instance: InAppMessaging = NotInitializedInAppMessaging()
@@ -138,6 +140,6 @@ abstract class InAppMessaging internal constructor() {
 
         override fun getHostAppContext(): Context? = null
 
-        override fun closeMessage() {}
+        override fun closeMessage(clearQueuedCampaigns: Boolean) {}
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
@@ -39,4 +39,12 @@ internal interface Message {
     fun getMaxImpressions(): Int?
 
     fun getContexts(): List<String>
+
+    /**
+     * This method returns the number of times this message has been queued (ready for display)
+     * but was removed when closeMessage API was called.
+     */
+    fun getNumberOfTimesClosed(): Int
+
+    fun incrementTimesClosed()
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
@@ -41,10 +41,14 @@ internal interface Message {
     fun getContexts(): List<String>
 
     /**
-     * This method returns the number of times this message has been queued (ready for display)
-     * but was removed when closeMessage API was called.
+     * Returns the number of times this message has been queued (ready for display) but was removed
+     * when closeMessage API was called.
      */
     fun getNumberOfTimesClosed(): Int
 
+    /**
+     * Increments the number of times this message has been queued (ready for display) but
+     * was removed when closeMessage API was called.
+     */
     fun incrementTimesClosed()
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
@@ -24,4 +24,10 @@ internal interface MessageRepository {
      * This is done during session update due to user info update.
      */
     fun clearMessages()
+
+    /**
+     * Clears all message from the repository.
+     * This is done during session update due to user info update.
+     */
+    fun incrementTimesClosed(messageList: List<Message>)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
@@ -26,8 +26,7 @@ internal interface MessageRepository {
     fun clearMessages()
 
     /**
-     * Clears all message from the repository.
-     * This is done during session update due to user info update.
+     * Increments the number of times closed for all the messages in the [messageList].
      */
     fun incrementTimesClosed(messageList: List<Message>)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
@@ -26,7 +26,8 @@ internal interface MessageRepository {
     fun clearMessages()
 
     /**
-     * Increments the number of times closed for all the messages in the [messageList].
+     * Increments the number of times closed while in queue (ready for display)
+     * for all the messages in the [messageList].
      */
     fun incrementTimesClosed(messageList: List<Message>)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
@@ -43,5 +43,10 @@ internal abstract class PingResponseMessageRepository : MessageRepository {
         override fun clearMessages() {
             messages.clear()
         }
+
+        override fun incrementTimesClosed(messageList: List<Message>) {
+            messages.filter { m -> messageList.any { it.getCampaignId() == m.key } }
+                    .forEach { it.value.incrementTimesClosed() }
+        }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
@@ -46,9 +46,9 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
             }
         }
 
-        override fun clearMessages(isClearQueued: Boolean) {
+        override fun clearMessages(shouldIncrementTimesClosed: Boolean) {
             synchronized(messages) {
-                if (isClearQueued) {
+                if (shouldIncrementTimesClosed) {
                     PingResponseMessageRepository.instance().incrementTimesClosed(messages)
                 }
                 messages.clear()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
@@ -30,16 +30,27 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
 
         override fun getAllMessagesCopy(): List<Message> = ArrayList(messages)
 
-        override fun removeMessage(campaignId: String) {
+        override fun removeMessage(campaignId: String, shouldIncrementTimesClosed: Boolean) {
             synchronized(messages) {
                 messages.removeAll { message ->
-                    message.getCampaignId() == campaignId
+                    if (message.getCampaignId() == campaignId) {
+                        // messages contain unique message (no two message have the same campaign id)
+                        if (shouldIncrementTimesClosed) {
+                            PingResponseMessageRepository.instance().incrementTimesClosed(listOf(message))
+                        }
+                        true
+                    } else {
+                        false
+                    }
                 }
             }
         }
 
-        override fun clearMessages() {
+        override fun clearMessages(isClearQueued: Boolean) {
             synchronized(messages) {
+                if (isClearQueued) {
+                    PingResponseMessageRepository.instance().incrementTimesClosed(messages)
+                }
                 messages.clear()
             }
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyMessageRepository.kt
@@ -20,12 +20,15 @@ internal interface ReadyMessageRepository {
 
     /**
      * Removing a message from the repository.
+     * @param campaignId id of the message to be removed.
+     * @param shouldIncrementTimesClosed if true, the number of times closed while in queue is incremented.
      */
     fun removeMessage(campaignId: String, shouldIncrementTimesClosed: Boolean = false)
 
     /**
-     * Clears all message from the repository.
-     * This is done during session update due to user info update.
+     * Clears all message from the repository. This is called during session update due to user info update,
+     * or when clearing of queued (ready for display) messages.
+     * @param shouldIncrementTimesClosed if true, the number of times closed while in queue is incremented.
      */
-    fun clearMessages(isClearQueued: Boolean = false)
+    fun clearMessages(shouldIncrementTimesClosed: Boolean = false)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyMessageRepository.kt
@@ -21,11 +21,11 @@ internal interface ReadyMessageRepository {
     /**
      * Removing a message from the repository.
      */
-    fun removeMessage(campaignId: String)
+    fun removeMessage(campaignId: String, shouldIncrementTimesClosed: Boolean = false)
 
     /**
      * Clears all message from the repository.
      * This is done during session update due to user info update.
      */
-    fun clearMessages()
+    fun clearMessages(isClearQueued: Boolean = false)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignData.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignData.kt
@@ -21,6 +21,8 @@ internal data class CampaignData(
     private val maxImpressions: Int
 ) : Message {
 
+    private var timesQueued = 0
+
     override fun getType(): Int = type
 
     override fun getCampaignId(): String = campaignId
@@ -37,5 +39,14 @@ internal data class CampaignData(
         val regex = Regex("\\[(.*?)\\]")
         val matches = regex.findAll(messagePayload.title ?: "")
         return matches.map { it.groupValues[1] }.toList()
+    }
+
+    override fun getNumberOfTimesClosed() = synchronized(timesQueued) {
+        timesQueued
+    }
+    override fun incrementTimesClosed() {
+        synchronized(timesQueued) {
+            timesQueued++
+        }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
@@ -260,8 +260,10 @@ internal interface MessageEventReconciliationUtil {
             val displayedImpression: Int = LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message)
 
             // Only check for message has been displayed less than its max impressions.
+            // The number of times the message was removed from ready for display repository is considered since local
+            // event list was not cleared and the triggers should  all be satisfied again.
             return if (maxImpression != null && displayedImpression < maxImpression) {
-                displayedImpression + 1
+                displayedImpression + 1 + message.getNumberOfTimesClosed()
             } else 0
         }
 
@@ -291,7 +293,7 @@ internal interface MessageEventReconciliationUtil {
                 entry.setValue(Collections.unmodifiableList(entry.value))
             }
             // Return an unmodifiable map.
-            return Collections.unmodifiableMap<String, MutableList<Event>>(eventMap)
+            return Collections.unmodifiableMap(eventMap)
         }
 
         /**

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -137,13 +137,26 @@ class InAppMessagingSpec : BaseTest() {
     }
 
     @Test
+    @Suppress("SwallowedException")
+    fun `should not crash close message for initialized instance`() {
+        initializeInstance()
+
+        try {
+            InAppMessaging.instance().closeMessage()
+            InAppMessaging.instance().closeMessage(true)
+        } catch (e: Exception) {
+            fail("should not throw exception")
+        }
+    }
+
+    @Test
     fun `should remove message from host activity and not clear queue`() {
         val message = ValidTestMessage("1")
         setupDisplayedView(message)
         initializeInstance()
 
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
-        InAppMessaging.instance().closeMessage()
+        (InAppMessaging.instance() as InApp).removeMessage(false)
         Mockito.verify(parentViewGroup).removeView(viewGroup)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
@@ -163,7 +176,7 @@ class InAppMessagingSpec : BaseTest() {
         initializeInstance()
 
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
-        InAppMessaging.instance().closeMessage(true)
+        (InAppMessaging.instance() as InApp).removeMessage(true)
         Mockito.verify(parentViewGroup).removeView(viewGroup)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldBeEmpty()
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
@@ -173,14 +186,14 @@ class InAppMessagingSpec : BaseTest() {
     }
 
     @Test
-    fun `should not crash and not increment when no message is displayed`() {
+    fun `should not increment when no message is displayed`() {
         val message = ValidTestMessage("1")
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
         PingResponseMessageRepository.instance().replaceAllMessages(listOf(message))
         initializeInstance()
 
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
-        InAppMessaging.instance().closeMessage()
+        (InAppMessaging.instance() as InApp).removeMessage(false)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
             msg.getNumberOfTimesClosed() shouldBeEqualTo 0
@@ -189,14 +202,14 @@ class InAppMessagingSpec : BaseTest() {
     }
 
     @Test
-    fun `should should clear and increment when no message is displayed but flag true`() {
+    fun `should clear and increment when no message is displayed but flag true`() {
         val message = ValidTestMessage("1")
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))
         PingResponseMessageRepository.instance().replaceAllMessages(listOf(message))
         initializeInstance()
 
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
-        InAppMessaging.instance().closeMessage(true)
+        (InAppMessaging.instance() as InApp).removeMessage(true)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldBeEmpty()
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
             msg.getNumberOfTimesClosed() shouldBeEqualTo 1

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -30,6 +30,7 @@ import kotlin.test.fail
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
+@SuppressWarnings("LargeClass")
 class InAppMessagingSpec : BaseTest() {
     private val activity = Mockito.mock(Activity::class.java)
     private val configResponseData = Mockito.mock(ConfigResponseData::class.java)
@@ -202,7 +203,7 @@ class InAppMessagingSpec : BaseTest() {
         }
         LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
     }
-  
+
     @Test
     fun `should remove message but not clear repo when activity is unregistered`() {
         val message = ValidTestMessage("1")
@@ -230,7 +231,7 @@ class InAppMessagingSpec : BaseTest() {
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
         LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
     }
-  
+
     private fun setupDisplayedView(message: Message) {
         val message2 = ValidTestMessage()
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message, message2))

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/InvalidTestMessage.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/InvalidTestMessage.kt
@@ -17,4 +17,9 @@ internal class InvalidTestMessage : Message {
     override fun getMaxImpressions(): Int = 0
 
     override fun getContexts(): List<String> = listOf()
+
+    override fun getNumberOfTimesClosed() = 0
+
+    @SuppressWarnings("EmptyFunctionBlock")
+    override fun incrementTimesClosed() {}
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/ValidTestMessage.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/ValidTestMessage.kt
@@ -5,10 +5,11 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Messag
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigger
 
 internal class ValidTestMessage(var id: String = DEFAULT_CAMPAIGN_ID, private val isTest: Boolean = IS_TEST) : Message {
+    internal var timesClosed = 0
 
     override fun getType(): Int = InAppMessageType.MODAL.typeId
 
-    override fun getCampaignId(): String? = id
+    override fun getCampaignId() = id
 
     override fun getTriggers(): List<Trigger>? {
         val triggerList = ArrayList<Trigger>()
@@ -23,6 +24,12 @@ internal class ValidTestMessage(var id: String = DEFAULT_CAMPAIGN_ID, private va
     override fun getMaxImpressions(): Int = 1
 
     override fun getContexts(): List<String> = listOf()
+
+    override fun getNumberOfTimesClosed() = timesClosed
+
+    override fun incrementTimesClosed() {
+        timesClosed++
+    }
 
     @Suppress("ComplexCondition")
     override fun equals(other: Any?): Boolean {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
@@ -14,19 +14,20 @@ import org.junit.Test
  * Test class for PingResponseMessageRepository.
  */
 class PingResponseMessageRepositorySpec : BaseTest() {
+    private val message0 = ValidTestMessage()
+    private val message1 = ValidTestMessage("1234")
+    private val messageList = ArrayList<Message>()
 
     @Before
     fun setup() {
         PingResponseMessageRepository.instance().clearMessages()
+        messageList.clear()
+        messageList.add(message0)
+        messageList.add(message1)
     }
 
     @Test
     fun `should add message list with valid list`() {
-        val messageList = ArrayList<Message>()
-        val message0 = ValidTestMessage()
-        val message1 = ValidTestMessage("1234")
-        messageList.add(message0)
-        messageList.add(message1)
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
         PingResponseMessageRepository.instance().getAllMessagesCopy()[0] shouldBeEqualTo message0
@@ -50,11 +51,6 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should be empty after clearing`() {
-        val messageList = ArrayList<Message>()
-        val message0 = ValidTestMessage()
-        val message1 = ValidTestMessage("1234")
-        messageList.add(message0)
-        messageList.add(message1)
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
 
@@ -64,11 +60,6 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should contain correct messages after clearing then adding`() {
-        val messageList = ArrayList<Message>()
-        val message0 = ValidTestMessage()
-        val message1 = ValidTestMessage("1234")
-        messageList.add(message0)
-        messageList.add(message1)
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
 
@@ -77,5 +68,36 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+    }
+
+    @Test
+    fun `should increment all matching from single item`() {
+        PingResponseMessageRepository.instance().replaceAllMessages(messageList)
+        PingResponseMessageRepository.instance().incrementTimesClosed(listOf(message0))
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            if (msg.getCampaignId() != "1234") {
+                msg.getNumberOfTimesClosed() shouldBeEqualTo 1
+            } else {
+                msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+            }
+        }
+    }
+
+    @Test
+    fun `should increment all matching from multiple items`() {
+        PingResponseMessageRepository.instance().replaceAllMessages(messageList)
+        PingResponseMessageRepository.instance().incrementTimesClosed(messageList)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `should not increment if no matching`() {
+        PingResponseMessageRepository.instance().replaceAllMessages(messageList)
+        PingResponseMessageRepository.instance().incrementTimesClosed(listOf(ValidTestMessage("4321")))
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+        }
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepositorySpec.kt
@@ -4,15 +4,32 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.ValidTestMessage
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldHaveSize
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 /**
  * Test class for ReadyForDisplayMessageRepository.
  */
 class ReadyForDisplayMessageRepositorySpec : BaseTest() {
+    private val messageList = ArrayList<Message>()
+    private val message0 = ValidTestMessage()
+    private val message1 = ValidTestMessage("1234")
+
+    @Before
+    fun setup() {
+        ReadyForDisplayMessageRepository.instance().clearMessages()
+        PingResponseMessageRepository.instance().clearMessages()
+        message0.timesClosed = 0
+        message1.timesClosed = 0
+        messageList.add(message0)
+        messageList.add(message1)
+        PingResponseMessageRepository.instance().replaceAllMessages(messageList)
+    }
+
     @Test
     fun `should throw exception when list is null`() {
         try {
@@ -25,11 +42,6 @@ class ReadyForDisplayMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should be empty after clearing`() {
-        val messageList = ArrayList<Message>()
-        val message0 = ValidTestMessage()
-        val message1 = ValidTestMessage("1234")
-        messageList.add(message0)
-        messageList.add(message1)
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
 
@@ -39,11 +51,6 @@ class ReadyForDisplayMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should contain correct messages after clearing then adding`() {
-        val messageList = ArrayList<Message>()
-        val message0 = ValidTestMessage()
-        val message1 = ValidTestMessage("1234")
-        messageList.add(message0)
-        messageList.add(message1)
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
 
@@ -52,5 +59,69 @@ class ReadyForDisplayMessageRepositorySpec : BaseTest() {
 
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+    }
+
+    @Test
+    fun `should remove matching message and increment times closed`() {
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().removeMessage(message0.getCampaignId(), true)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            if (msg.getCampaignId() == message0.getCampaignId()) {
+                msg.getNumberOfTimesClosed() shouldBeEqualTo 1
+            } else {
+                msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+            }
+        }
+    }
+
+    @Test
+    fun `should remove matching message but not increment`() {
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().removeMessage(message0.getCampaignId(), false)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `should not remove and not increment when no match`() {
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().removeMessage("4321", false)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `should not remove and not increment when no match and flag true`() {
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().removeMessage("4321", true)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `should clear messages and increment times closed`() {
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().clearMessages(true)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldBeEmpty()
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `should clear messages but not increment times closed`() {
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().clearMessages(false)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldBeEmpty()
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+        }
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
@@ -280,4 +280,17 @@ class MessageMixerResponseSpec(private val testname: String, private val actual:
         val campaign = generateDummyCampaign("id", null)
         campaign.getContexts() shouldHaveSize 0
     }
+
+    @Test
+    fun `should not always start times closed to zero`() {
+        val campaign = generateDummyCampaign("id", "")
+        campaign.getNumberOfTimesClosed() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `should have correct incremented value`() {
+        val campaign = generateDummyCampaign("id", "")
+        campaign.incrementTimesClosed()
+        campaign.getNumberOfTimesClosed() shouldBeEqualTo 1
+    }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -13,6 +13,7 @@ import com.facebook.datasource.DataSource
 import com.facebook.soloader.SoLoader
 import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
@@ -248,7 +249,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         argumentCaptor<String>().apply {
-            Mockito.verify(mockReadyForDisplayRepo, Mockito.times(1)).removeMessage(capture())
+            Mockito.verify(mockReadyForDisplayRepo, Mockito.times(1)).removeMessage(capture(), eq(false))
             firstValue shouldBeEqualTo message.getCampaignId()
         }
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
@@ -150,13 +150,7 @@ class MessageEventReconciliationUtilReconcileSpec : MessageEventReconciliationUt
         // Arrange input data.
         val inputMessageList = ArrayList<Message>()
         inputMessageList.add(message2)
-        val triggerAttr = TriggerAttribute("name", "value", 1, 1)
-        val attrList = ArrayList<TriggerAttribute>()
-        attrList.add(triggerAttr)
-        When calling trigger1.triggerAttributes itReturns attrList
-        When calling trigger1.eventType itReturns 4
-        When calling trigger1.eventName itReturns "custom"
-        customEvent.addAttribute("name", "value")
+        setupCustomEventStringAttribute()
         LocalEventRepository.instance().addEvent(customEvent)
         // Act.
         val outputMessageList = MessageEventReconciliationUtil.instance()
@@ -222,6 +216,35 @@ class MessageEventReconciliationUtilReconcileSpec : MessageEventReconciliationUt
         val outputMessageList = MessageEventReconciliationUtil.instance()
                 .reconcileMessagesAndEvents(inputMessageList)
         // Re-assert the output with qualifying event.
+        outputMessageList.shouldHaveSize(1)
+    }
+
+    @Test
+    fun `should not reconcile message when events are not enough due to times closed`() {
+        val inputMessageList = ArrayList<Message>()
+        inputMessageList.add(message2)
+        When calling message2.getNumberOfTimesClosed() itReturns 1
+        setupCustomEventStringAttribute()
+        LocalEventRepository.instance().addEvent(customEvent)
+
+        val outputMessageList = MessageEventReconciliationUtil.instance()
+                .reconcileMessagesAndEvents(inputMessageList)
+
+        outputMessageList.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should reconcile message when events are enough with to times closes`() {
+        val inputMessageList = ArrayList<Message>()
+        inputMessageList.add(message2)
+        When calling message2.getNumberOfTimesClosed() itReturns 1
+        setupCustomEventStringAttribute()
+        LocalEventRepository.instance().addEvent(customEvent)
+        LocalEventRepository.instance().addEvent(customEvent)
+
+        val outputMessageList = MessageEventReconciliationUtil.instance()
+                .reconcileMessagesAndEvents(inputMessageList)
+
         outputMessageList.shouldHaveSize(1)
     }
 
@@ -381,6 +404,16 @@ class MessageEventReconciliationUtilReconcileSpec : MessageEventReconciliationUt
         outputMessageList = MessageEventReconciliationUtil.instance().reconcileMessagesAndEvents(inputMessageList)
         // Re-assert the output with qualifying event.
         outputMessageList.shouldHaveSize(0)
+    }
+
+    private fun setupCustomEventStringAttribute() {
+        val triggerAttr = TriggerAttribute("name", "value", 1, 1)
+        val attrList = ArrayList<TriggerAttribute>()
+        attrList.add(triggerAttr)
+        When calling trigger1.triggerAttributes itReturns attrList
+        When calling trigger1.eventType itReturns 4
+        When calling trigger1.eventName itReturns "custom"
+        customEvent.addAttribute("name", "value")
     }
 }
 


### PR DESCRIPTION
# Description
add closed counter to the `CampaignData` to consider in the number of events to trigger.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors