### PR TITLE
feat: [SDKCF-3219] add removing of displayed message when app unregister activity

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -55,6 +55,7 @@ internal class InApp(
 
     @Suppress("FunctionMaxLength")
     override fun unregisterMessageDisplayActivity() {
+        displayManager.removeMessage(getRegisteredActivity())
         activityWeakReference?.clear()
 
         Timber.tag(TAG)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -273,6 +273,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
     @Test
     fun `should not display campaign if activity is not registered`() {
         InAppMessaging.instance().unregisterMessageDisplayActivity()
+        Mockito.verify(activity).findViewById<View?>(ArgumentMatchers.anyInt())
         val message = Mockito.mock(Message::class.java)
 
         When calling message.getCampaignId() itReturns "1"
@@ -284,8 +285,8 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        Mockito.verify(activity, Mockito.times(0))
-                .findViewById<View?>(ArgumentMatchers.anyInt())
+        // will be called only once when activity was unregistered
+        Mockito.verify(activity).findViewById<View?>(ArgumentMatchers.anyInt())
     }
 
     @Test


### PR DESCRIPTION
# Description
This is an expected behavior but was not implemented from the original code (in Java)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors