### PR TITLE
fix: manual handling for timeout

### DIFF
--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -62,7 +62,6 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
   implementation 'com.squareup.retrofit2:retrofit:2.8.1'
   implementation 'com.github.bumptech.glide:glide:4.12.0'
-  annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
   implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
   implementation 'com.rakuten.tech.mobile:manifest-config-annotations:0.1.0'
   kapt 'com.rakuten.tech.mobile:manifest-config-processor:0.1.0'

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
@@ -85,9 +85,8 @@ internal class DisplayMessageRunnable(
     private fun downloadImage(view: InAppMessageBaseView, message: Message) {
         val url = message.getMessagePayload()?.resource?.imageUrl
         if (url != null) {
-            val imageView = view.findViewById<ImageView>(R.id.message_image_view)
             Glide.with(hostActivity).load(url).timeout(IMG_DOWNLOAD_TIMEOUT).into(
-                    object : ImageViewTarget<Drawable>(imageView) {
+                    object : ImageViewTarget<Drawable>(view.findViewById(R.id.message_image_view)) {
                         override fun onLoadStarted(placeholder: Drawable?) {
                             super.onLoadStarted(placeholder)
                             // hide campaign view (cannot use visibility since Glide callback will not work.)

--- a/inappmessaging/src/main/res/layout/message_image_view.xml
+++ b/inappmessaging/src/main/res/layout/message_image_view.xml
@@ -7,4 +7,5 @@
   android:contentDescription="@string/in_app_message_image"
   android:scaleType="fitCenter"
   android:visibility="gone"
+  android:adjustViewBounds="true"
   tools:visibility="visible"/>


### PR DESCRIPTION
# Description
added manual timer for handling failed image download since Glide does not trigger callback immediately after timeout

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors