### PR TITLE
ci: update config for publishing to maven central instead of bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android-sdk: rakutentech/android-sdk@0.2.0
+  android-sdk: rakutentech/android-sdk@0.2.1
   slack: circleci/slack@4.2.0
 
 jobs:
@@ -57,6 +57,12 @@ workflows:
       - android-sdk/publish:
           requires:
             - release-verification
+          after-prepare-steps:
+            # Retrieve Base64 PGP Key and save to file
+            - run: |
+                if [[ "$RELEASE_PGP_KEY_BASE64" != "" ]]; then
+                  base64 -d \<<< "$RELEASE_PGP_KEY_BASE64" > ./maven-central-key.gpg
+                fi
           post-steps:
             - run:
                 name: Publish Documentation

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.rakutentech.inappmessaging/inappmessaging)](https://search.maven.org/artifact/io.github.rakutentech.inappmessaging/inappmessaging)
 [![CircleCI](https://circleci.com/gh/rakutentech/android-inappmessaging.svg?style=svg)](https://circleci.com/gh/rakutentech/android-inappmessaging)
 [![codecov](https://codecov.io/gh/rakutentech/android-inappmessaging/branch/master/graph/badge.svg)](https://codecov.io/gh/rakutentech/android-inappmessaging)
 
@@ -13,14 +14,6 @@ This repository uses submodules for some configuration, so they must be initiali
 $ git submodule init
 $ git submodule update
 $ ./gradlew assemble
-```
-
-If you wish to publish an artifact to JCenter, you must set the Bintray credentials as environment variables.
-
-```bash
-$ export BINTRAY_USER=user_name
-$ export BINTRAY_KEY=key
-$ export BINTRY_REPO=repo_name
 ```
 
 ## How to test the Sample app

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     repositories {
         google()
         gradle()
+        mavenCentral()
         jcenter()
         jitpack()
     }
@@ -32,6 +33,7 @@ plugins {
 allprojects { proj ->
     repositories {
         google()
+        mavenCentral()
         jcenter()
         jitpack()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
     ext.dokka_version = '0.10.0'
     // Build Config.
     apply from: 'config/index.gradle'
@@ -7,7 +6,7 @@ buildscript {
     CONFIG.versions.android.sdk.min = 21
     CONFIG.versions.android.sdk.target = 30
     CONFIG.versions.android.sdk.compile = 30
-    CONFIG.versions.kotlin = '1.4.10'
+    CONFIG.versions.kotlin = '1.4.31'
 
     repositories {
         google()
@@ -26,7 +25,7 @@ buildscript {
 }
 
 plugins {
-    id 'net.ltgt.errorprone' version '1.1.1' apply false
+    id 'net.ltgt.errorprone' version '1.3.0' apply false
     id 'io.gitlab.arturbosch.detekt' version '1.1.1'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,3 @@ application_id=com.rakuten.tech.mobile.inappmessaging
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableD8=true
-# ---------------------------------- Robolectric flags -------------------------------------------
-android.enableUnitTestBinaryResources=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,15 @@
 # ---------------------------------- InAppMessaging SDK flags ------------------------------------
-group=com.rakuten.tech.mobile.inappmessaging
+group=io.github.rakutentech.inappmessaging
 name=inappmessaging
 description=In App Messaging Android SDK.
 url=https://github.com/rakutentech/android-inappmessaging.git
 licenseName="MIT License"
 licenseUrl=https://opensource.org/licenses/MIT
 scmUrl=https://github.com/rakutentech/android-inappmessaging.git
+developerName=Rakutentech
+developerEmail=mtsd-sdk-oss@mail.rakuten.com
+developerOrganization=Rakuten
+developerOrganizationUrl=https://rakutentech.github.io/
 # In-App Messaging SDK info for Android.
 application_id=com.rakuten.tech.mobile.inappmessaging
 # ---------------------------------- AndroidX flags ----------------------------------------------

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Mar 16 15:38:00 JST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -266,6 +266,24 @@ buildscript {
 ```
 </details>
 
+<details>
+<summary>Build Error: `java.lang.RuntimeException: Duplicate class com.rakuten.tech.mobile.manifestconfig.annotations.ManifestConfig`</summary>
+
+This build error could occur if you are using older versions of other libraries from `com.rakuten.tech.mobile`.
+Some of the dependencies in this SDK have changed to a new Group ID of `io.github.rakutentech` (due to the [JCenter shutdown](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)).
+This means that if you have another library in your project which depends on the older dependencies using the Gropu ID `com.rakuten.tech.mobile`, then you will have duplicate classes.
+
+To avoid this, please add the following to your `build.gradle` in order to exclude the old `com.rakuten.tech.mobile` dependencies from your project.
+
+```groovy
+configurations.all {
+    exclude group: 'com.rakuten.tech.mobile', module: 'manifest-config-processor'
+    exclude group: 'com.rakuten.tech.mobile', module: 'manifest-config-annotations'
+}
+```
+
+</details>
+
 ### Other Issues
 Rakuten developers experiencing any other problems should refer to the Troubleshooting Guide on the internal developer documentation portal.
 

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -29,7 +29,7 @@ You must have a subscription key for your application from IAM Dashboard.
 ```groovy
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 ```
@@ -40,7 +40,7 @@ Note: InAppMessaging SDK only uses AndroidX libraries. Host apps should migrate 
 
 ```groovy
 dependencies {
-    implementation 'com.rakuten.tech.mobile.inappmessaging:inappmessaging:${latest_version}'
+    implementation 'io.github.rakutentech.inappmessaging:inappmessaging:${latest_version}'
 }
 ```
 Please refer to [Changelog](#changelog) section for the latest version.
@@ -294,8 +294,11 @@ Documents targeting Product Managers:
 
 ## <a name="changelog"></a> Changelog
 
-### 2.3.1 (in-progress)
+### 3.0.0 (in-progress)
 * SDKCF-3450: Update Fresco dependency to v2.4.0 to fix SoLoader issue.
+* SDKCF-3454: Changed Maven Group ID to `io.github.rakutentech.inappmessaging`. You must update your dependency declarations to the following:
+  - `io.github.rakutentech.inappmessaging:inappmessaging:3.0.0`
+* Migrated publishing to Maven Central due to Bintray/JCenter being [shutdown](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). You must add `mavenCentral()` to your `repositories`.
 
 ### 2.3.0 (2021-02-24)
 * SDKCF-3199: Add [`closeMessage` API](#close-campaign) for programmatically closing campaigns without user action.
@@ -311,8 +314,8 @@ Documents targeting Product Managers:
 
 ### 2.1.0 (2020-09-18)
 * SDKCF-2568: Deprecate updateSession() API
- * session update will be done internally when event is triggered and user info was changed
- * will be removed on 3.0.0
+  - session update will be done internally when event is triggered and user info was changed
+  - will be removed on next major version
 
 ### 2.0.0 (2020-06-11)
 * SDKCF-2054: Converted In-App Messaging to Kotlin

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -1,5 +1,4 @@
 apply from: '../config/android/library.gradle'
-//apply from: '../config/quality/android.gradle'
 apply from: "../config/quality/checkstyle/android.gradle"
 apply from: "../config/quality/detekt/android.gradle"
 apply from: '../config/quality/errorprone/android.gradle'
@@ -65,8 +64,8 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
   implementation 'com.squareup.retrofit2:retrofit:2.8.1'
   implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-  implementation 'io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0'
-  kapt 'io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0'
+  kapt "io.github.rakutentech.manifestconfig:manifest-config-processor:0.2.0"
+  implementation "io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0"
 
   // Doclava needs an annotation class from this package (used by Retrofit)
   compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.18'
@@ -84,11 +83,6 @@ dependencies {
   testImplementation "com.facebook.soloader:soloader:0.9.0"
 
   detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.1.1"
-  if(!JavaVersion.current().java9Compatible) {
-    // see https://github.com/tbroyer/gradle-errorprone-plugin#jdk-8-support
-    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
-  }
-  errorprone 'com.google.errorprone:error_prone_core:2.3.2'
 }
 
 task checkUrlPrefixes {

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -1,5 +1,6 @@
 apply from: '../config/android/library.gradle'
-apply from: '../config/quality/android.gradle'
+//apply from: '../config/quality/android.gradle'
+apply from: "../config/quality/checkstyle/android.gradle"
 apply from: "../config/quality/detekt/android.gradle"
 apply from: '../config/quality/errorprone/android.gradle'
 apply from: '../config/documentation/dokka/android.gradle'

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -64,8 +64,8 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
   implementation 'com.squareup.retrofit2:retrofit:2.8.1'
   implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-  implementation 'com.rakuten.tech.mobile:manifest-config-annotations:0.1.0'
-  kapt 'com.rakuten.tech.mobile:manifest-config-processor:0.1.0'
+  implementation 'io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0'
+  kapt 'io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0'
 
   // Doclava needs an annotation class from this package (used by Retrofit)
   compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.18'
@@ -133,7 +133,7 @@ if (isSnapshot) {
   project.ext.ARTIFACTORY_REPO=CONFIG.property("ARTIFACTORY_REPO_SNAPSHOT")
   apply from: '../config/publish/artifactory.gradle'
 } else {
-  apply from: '../config/publish/bintray.gradle'
+  apply from: '../config/publish/maven-central.gradle'
 }
 
 dokka {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -11,7 +11,6 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyFor
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.SessionManager
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -24,7 +23,6 @@ internal class InApp(
     private val displayManager: DisplayManager = DisplayManager.instance()
 ) : InAppMessaging() {
 
-    @SuppressFBWarnings("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR") // No need to initialize.
     // Used for displaying or removing messages from screen.
     private var activityWeakReference: WeakReference<Activity>? = null
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/Impression.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/Impression.kt
@@ -2,19 +2,16 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.models
 
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.ImpressionType
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class represents impression object.
  */
 internal data class Impression(
     private val impType: ImpressionType,
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
     @SerializedName("timestamp")
     val timestamp: Long
 ) {
 
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
     @SerializedName("type")
     val type = impType.typeId
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/UserIdentifier.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/UserIdentifier.kt
@@ -2,19 +2,16 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.models
 
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.UserIdentifierType
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class represents user identification.
  */
 internal data class UserIdentifier(
     private val idType: UserIdentifierType,
-    @property:SuppressFBWarnings("URF_UNREAD_FIELD")
     @SerializedName("id")
     private val id: String
 ) {
 
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
     @SerializedName("type")
     private val type = idType.typeId
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/rat/RatAttribute.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/rat/RatAttribute.kt
@@ -1,13 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.models.rat
 
 import com.google.gson.annotations.SerializedName
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class contains just name and value attributes.
  * Specially made for broadcasting RAT events.
  */
-@SuppressFBWarnings("URF_UNREAD_FIELD")
 @SuppressWarnings("PMD")
 internal data class RatAttribute(
     @SerializedName("name") private val name: String,

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/rat/RatImpression.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/rat/RatImpression.kt
@@ -1,12 +1,10 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.models.rat
 
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.ImpressionType
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class specifically made for broadcasting impressions to RAT.
  */
-@SuppressFBWarnings("URF_UNREAD_FIELD")
 internal data class RatImpression(private val impressionType: ImpressionType, private val timestamp: Long) {
 
     private val action = impressionType.typeId

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigRequest.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigRequest.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.requests
 
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class represents the request body for config request.
@@ -19,6 +18,5 @@ internal data class ConfigRequest(
 ) {
 
     @SerializedName("platform")
-    @SuppressFBWarnings("SS_SHOULD_BE_STATIC")
     private val platform = InAppMessagingConstants.ANDROID_PLATFORM_ENUM
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequest.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequest.kt
@@ -3,12 +3,10 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.requests
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.UserIdentifier
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class represents the request body for message display permission request.
  */
-@SuppressFBWarnings("URF_UNREAD_FIELD") // No getter needed.
 @SuppressWarnings("ObjectToString") // toString() method is not needed for this class.
 internal data class DisplayPermissionRequest(
     @SerializedName("campaignId")

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequest.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequest.kt
@@ -2,12 +2,10 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.requests
 
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.UserIdentifier
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 /**
  * This class represents the request body for ping request.
  */
-@SuppressFBWarnings("URF_UNREAD_FIELD")
 internal data class PingRequest(
     @SerializedName("appVersion")
     private val appVersion: String?, // NOPMD

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
@@ -9,7 +9,6 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Messa
 import com.rakuten.tech.mobile.inappmessaging.runtime.view.InAppMessageFullScreenView
 import com.rakuten.tech.mobile.inappmessaging.runtime.view.InAppMessageModalView
 import com.rakuten.tech.mobile.inappmessaging.runtime.view.InAppMessageSlideUpView
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.coroutines.Runnable
 
 /**
@@ -27,7 +26,6 @@ internal class DisplayMessageRunnable(
      * Interface method which will be invoked by the Virtual Machine. This is also the actual method
      * which will display message with correct data.
      */
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE") // No need to check casting.
     @UiThread
     @Suppress("LongMethod")
     override fun run() {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
@@ -12,7 +12,6 @@ import com.google.android.material.button.MaterialButton
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.MessageButton
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.android.synthetic.main.close_button.view.*
 import kotlinx.android.synthetic.main.message_buttons.view.*
 import kotlinx.android.synthetic.main.message_image_view.view.*
@@ -62,7 +61,6 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
     /**
      * This method binds data to view.
      */
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE") // No need to check for casting type.
     // Warning: NPath complexity > 200. Explanation: Empty checks are OK.
     private fun bindViewData() {
         bindImage()
@@ -79,7 +77,6 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
     /**
      * This method binds data to buttons.
      */
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     private fun bindButtons() {
         // Set onClick listener to close button.
         val closeButton = message_close_button
@@ -152,7 +149,6 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
      * This method binds data to message header.
      */
     @SuppressLint("ClickableViewAccessibility")
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     @Suppress("LongMethod")
     private fun bindText() {
         if (!header.isNullOrEmpty() || !messageBody.isNullOrEmpty()) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageFullScreenView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageFullScreenView.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.widget.ImageButton
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.android.synthetic.main.close_button.view.*
 import kotlinx.android.synthetic.main.in_app_message_full_screen.view.*
 
@@ -22,7 +21,6 @@ internal class InAppMessageFullScreenView(
     /**
      * Populating view data.
      */
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     override fun populateViewData(message: Message, imageAspectRatio: Float) {
         super.populateViewData(message, imageAspectRatio)
         if (imageUrl.isNullOrEmpty()) {


### PR DESCRIPTION
# Description
because of Jcenter/bintray shutdown, publishing is done now to maven central
* class changes are only to removed findbugs annotations