### PR TITLE
feat: make local respositories persistent per user to move opt-out and max impression handling solely on SDK

### DIFF
--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -14,6 +14,7 @@ android {
     consumerProguardFiles 'proguard-rules.pro'
     manifestPlaceholders.config_url = CONFIG.property("CONFIG_URL") ?: ""
     manifestPlaceholders.test_sub_key = CONFIG.property("IAM_TEST_SUBSCRIPTION_KEY") ?: "test_sub_key"
+    buildConfigField("boolean", "IS_CACHE_HANDLING", "true")
   }
 
   sourceSets.each {
@@ -64,6 +65,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
   implementation 'com.squareup.retrofit2:retrofit:2.8.1'
   implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+  implementation 'com.google.code.gson:gson:2.8.6'
   kapt "io.github.rakutentech.manifestconfig:manifest-config-processor:0.2.0"
   implementation "io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0"
 
@@ -137,4 +139,9 @@ dokka {
       path = "inappmessaging/src/main"
     }
   }
+}
+
+apply from: "../config/quality/jacoco/android.gradle"
+jacoco {
+  toolVersion = "0.8.3"
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -11,16 +11,19 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyFor
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.SessionManager
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.SharePreferencesUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.ref.WeakReference
 
+@SuppressWarnings("TooManyFunctions")
 internal class InApp(
     private val context: Context,
     isDebugLogging: Boolean,
-    private val displayManager: DisplayManager = DisplayManager.instance()
+    private val displayManager: DisplayManager = DisplayManager.instance(),
+    private var isCacheHandling: Boolean = BuildConfig.IS_CACHE_HANDLING
 ) : InAppMessaging() {
 
     // Used for displaying or removing messages from screen.
@@ -76,6 +79,11 @@ internal class InApp(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     override fun getHostAppContext() = context
+
+    override fun isLocalCachingEnabled() = isCacheHandling
+
+    override fun getEncryptedSharedPref() = SharePreferencesUtil.createSharedPreference(context,
+            SharePreferencesUtil.generateKey(context), AccountRepository.instance().userInfoHash)
 
     override fun closeMessage(clearQueuedCampaigns: Boolean) {
         CoroutineScope(Dispatchers.Main).launch {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.inappmessaging.runtime
 
 import android.app.Activity
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
@@ -75,6 +76,18 @@ abstract class InAppMessaging internal constructor() {
     internal abstract fun getHostAppContext(): Context?
 
     /**
+     * This method returns flag if local caching feature is enabled.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    internal abstract fun isLocalCachingEnabled(): Boolean
+
+    /**
+     * This method returns the encrypted shared preference.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    internal abstract fun getEncryptedSharedPref(): SharedPreferences?
+
+    /**
      * Close the currently displayed message.
      * This should be called when app needs to force-close the displayed message without user action.
      * Calling this method will not increment the campaign impression.
@@ -109,7 +122,7 @@ abstract class InAppMessaging internal constructor() {
             isForTesting: Boolean = false,
             configScheduler: ConfigScheduler = ConfigScheduler.instance()
         ) {
-            instance = InApp(context, isDebugLogging)
+            instance = InApp(context, isDebugLogging, isCacheHandling = !isForTesting)
             // Initializing SDK using background worker thread.
             Initializer.initializeSdk(context, subscriptionKey, configUrl, isForTesting)
             configScheduler.startConfig()
@@ -139,6 +152,10 @@ abstract class InAppMessaging internal constructor() {
         override fun getRegisteredActivity(): Activity? = null
 
         override fun getHostAppContext(): Context? = null
+
+        override fun isLocalCachingEnabled() = false
+
+        override fun getEncryptedSharedPref(): SharedPreferences? = null
 
         override fun closeMessage(clearQueuedCampaigns: Boolean) {}
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -120,9 +120,10 @@ abstract class InAppMessaging internal constructor() {
             configUrl: String?,
             isDebugLogging: Boolean = false,
             isForTesting: Boolean = false,
+            isCacheHandling: Boolean = true,
             configScheduler: ConfigScheduler = ConfigScheduler.instance()
         ) {
-            instance = InApp(context, isDebugLogging, isCacheHandling = !isForTesting)
+            instance = InApp(context, isDebugLogging, isCacheHandling = isCacheHandling)
             // Initializing SDK using background worker thread.
             Initializer.initializeSdk(context, subscriptionKey, configUrl, isForTesting)
             configScheduler.startConfig()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -120,7 +120,7 @@ abstract class InAppMessaging internal constructor() {
             configUrl: String?,
             isDebugLogging: Boolean = false,
             isForTesting: Boolean = false,
-            isCacheHandling: Boolean = true,
+            isCacheHandling: Boolean = false,
             configScheduler: ConfigScheduler = ConfigScheduler.instance()
         ) {
             instance = InApp(context, isDebugLogging, isCacheHandling = isCacheHandling)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/Message.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigge
  * Interface for an InApp campaign message.
  * All in-app messages must implement this interface.
  */
+@SuppressWarnings("ComplexInterface")
 internal interface Message {
     /**
      * This method returns the message type.
@@ -37,6 +38,11 @@ internal interface Message {
      * This method returns max impressions.
      */
     fun getMaxImpressions(): Int?
+
+    /**
+     * This method sets max impressions.
+     */
+    fun setMaxImpression(maxImpression: Int)
 
     fun getContexts(): List<String>
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepository.kt
@@ -62,7 +62,7 @@ internal abstract class AccountRepository {
                 } else userInfoProvider!!.provideRakutenId().toString()
 
         override fun updateUserInfo(): Boolean {
-            val curr = hash(getUserId() + getRaeToken() + getRakutenId())
+            val curr = hash(getUserId() + getRakutenId())
 
             if (userInfoHash != curr) {
                 userInfoHash = curr

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -1,5 +1,8 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
 import java.util.Calendar
@@ -34,6 +37,7 @@ internal interface LocalDisplayedMessageRepository {
 
     companion object {
         private var instance: LocalDisplayedMessageRepository = LocalDisplayedMessageRepositoryImpl()
+        private const val LOCAL_DISPLAYED_KEY = "local_displayed_list"
 
         fun instance() = instance
     }
@@ -43,6 +47,11 @@ internal interface LocalDisplayedMessageRepository {
         // Such as:
         // {5bf41c52-e4c0-4cb2-9183-df429e84d681, [1537309879557,1537309879557,1537309879557]}
         private val messages = HashMap<String, List<Long>>()
+        private var user = ""
+
+        init {
+            checkAndResetMap(true)
+        }
 
         @Throws(IllegalArgumentException::class)
         override fun addMessage(message: Message?) {
@@ -51,25 +60,27 @@ internal interface LocalDisplayedMessageRepository {
 
             // Add a message to repository with time stamp.
             val campaignId = message.getCampaignId()
-            val currentTimeMilliUtc = Calendar.getInstance().timeInMillis
-            val timeStamps: List<Long>
+
             // Prevents race condition.
             synchronized(messages) {
+                checkAndResetMap()
+
                 if (!messages.containsKey(campaignId)) {
-                    timeStamps = ArrayList()
-                    timeStamps.add(currentTimeMilliUtc)
+                    val timeStamps = ArrayList<Long>()
+                    timeStamps.add(Calendar.getInstance().timeInMillis)
                     messages[campaignId!!] = timeStamps
                 } else {
-                    timeStamps = ArrayList(messages[campaignId]!!)
-                    timeStamps.add(currentTimeMilliUtc)
+                    val timeStamps = ArrayList(messages[campaignId]!!)
+                    timeStamps.add(Calendar.getInstance().timeInMillis)
                     messages[campaignId!!] = timeStamps
                 }
+                saveUpdatedMap()
             }
         }
 
         override fun numberOfTimesDisplayed(message: Message): Int {
-
             synchronized(messages) {
+                checkAndResetMap()
                 // Prevents race condition.
                 val messageTimeStampList = messages[message.getCampaignId()]
                 return messageTimeStampList?.size ?: 0
@@ -79,6 +90,32 @@ internal interface LocalDisplayedMessageRepository {
         override fun clearMessages() {
             if (messages.isNotEmpty()) {
                 messages.clear()
+                saveUpdatedMap()
+            }
+        }
+
+        private fun checkAndResetMap(onLaunch: Boolean = false) {
+            // check if caching is enabled and if there are changes in user info
+            if (InAppMessaging.instance().isLocalCachingEnabled() &&
+                    (onLaunch || user != AccountRepository.instance().userInfoHash)) {
+                user = AccountRepository.instance().userInfoHash
+                // reset message list from cached using updated user info
+                val listString = InAppMessaging.instance().getEncryptedSharedPref()?.getString(LOCAL_DISPLAYED_KEY, "")
+                        ?: ""
+                messages.clear()
+                if (listString.isNotEmpty()) {
+                    val type = object : TypeToken<HashMap<String, List<Long>>>() {}.type
+                    messages.putAll(Gson().fromJson(listString, type))
+                }
+            }
+        }
+
+        private fun saveUpdatedMap() {
+            // check if caching is enabled to update persistent data
+            if (InAppMessaging.instance().isLocalCachingEnabled()) {
+                // reset message list from cached using updated user info
+                InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(LOCAL_DISPLAYED_KEY,
+                        Gson().toJson(messages))?.apply()
             }
         }
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
+import timber.log.Timber
 import java.util.Calendar
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
@@ -38,6 +39,7 @@ internal interface LocalDisplayedMessageRepository {
     companion object {
         private var instance: LocalDisplayedMessageRepository = LocalDisplayedMessageRepositoryImpl()
         private const val LOCAL_DISPLAYED_KEY = "local_displayed_list"
+        private const val TAG = "IAM_LocalEventRepo"
 
         fun instance() = instance
     }
@@ -115,7 +117,7 @@ internal interface LocalDisplayedMessageRepository {
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
                 // reset message list from cached using updated user info
                 InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(LOCAL_DISPLAYED_KEY,
-                        Gson().toJson(messages))?.apply()
+                        Gson().toJson(messages))?.apply() ?: Timber.tag(TAG).d("failed saving map")
             }
         }
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -1,8 +1,16 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
 import androidx.annotation.VisibleForTesting
+import com.google.gson.Gson
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.EventType
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.AppStartEvent
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.CustomEvent
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.LoginSuccessfulEvent
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.PurchaseSuccessfulEvent
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
+import org.json.JSONArray
 import timber.log.Timber
 import java.util.Collections
 import kotlin.collections.ArrayList
@@ -28,12 +36,18 @@ internal interface LocalEventRepository : EventRepository {
     companion object {
         private const val TAG = "IAM_LocalEventRepo"
         private var instance: LocalEventRepository = LocalEventRepositoryImpl()
+        private const val LOCAL_EVENT_KEY = "local_event_list"
 
         fun instance() = instance
     }
 
     private class LocalEventRepositoryImpl : LocalEventRepository {
         private val events = ArrayList<Event>()
+        private var user = ""
+
+        init {
+            checkAndResetList(true)
+        }
 
         /**
          * This method adds logEvent into the events map.
@@ -46,16 +60,17 @@ internal interface LocalEventRepository : EventRepository {
             synchronized(events) {
                 // If persistent type, event should only be stored once.
                 if (shouldIgnore(event)) return false
+
+                checkAndResetList()
                 events.add(event)
                 Timber.tag(TAG).d(event.getEventName())
                 event.getAttributeMap().forEach { (key, value) ->
                     Timber.tag(TAG).d("Key: %s", key)
                     Timber.tag(TAG).d(
-                            "Value name: %s, Value Type: %d, Value data: %s",
-                            value?.name,
-                            value?.valueType,
+                            "Value name: %s, Value Type: %d, Value data: %s", value?.name, value?.valueType,
                             value?.value)
                 }
+                saveUpdatedList()
             }
             return true
         }
@@ -65,6 +80,8 @@ internal interface LocalEventRepository : EventRepository {
          */
         override fun getEvents(): List<Event> {
             synchronized(events) {
+                // check if caching is enabled and if there are changes in user info
+                checkAndResetList()
                 return Collections.unmodifiableList(events)
             }
         }
@@ -74,6 +91,7 @@ internal interface LocalEventRepository : EventRepository {
             synchronized(events) {
                 if (events.isNotEmpty()) {
                     events.clear()
+                    saveUpdatedList()
                 }
             }
         }
@@ -95,6 +113,52 @@ internal interface LocalEventRepository : EventRepository {
             }
 
             return false
+        }
+
+        private fun checkAndResetList(onLaunch: Boolean = false) {
+            // check if caching is enabled and if there are changes in user info
+            if (InAppMessaging.instance().isLocalCachingEnabled() &&
+                    (onLaunch || user != AccountRepository.instance().userInfoHash)) {
+                user = AccountRepository.instance().userInfoHash
+                // reset message list from cached using updated user info
+                val listString = InAppMessaging.instance().getEncryptedSharedPref()?.getString(LOCAL_EVENT_KEY, "")
+                        ?: ""
+                if (listString.isNotEmpty()) {
+                    events.clear()
+                    deserializeLocalEvents(listString)
+                } else if (events.isNotEmpty()) {
+                    // retain persistent event for user with no stored data
+                    events.removeAll { ev -> !ev.isPersistentType() }
+                }
+            }
+        }
+
+        private fun deserializeLocalEvents(listString: String) {
+            val jsonArray = JSONArray(listString)
+            for (i in 0 until jsonArray.length()) {
+                val item = jsonArray.getJSONObject(i)
+                val event = when (item["eventType"].toString()) {
+                    EventType.APP_START.name -> Gson().fromJson(item.toString(), AppStartEvent::class.java)
+                    EventType.LOGIN_SUCCESSFUL.name ->
+                        Gson().fromJson(item.toString(), LoginSuccessfulEvent::class.java)
+                    EventType.PURCHASE_SUCCESSFUL.name ->
+                        Gson().fromJson(item.toString(), PurchaseSuccessfulEvent::class.java)
+                    EventType.CUSTOM.name -> Gson().fromJson(item.toString(), CustomEvent::class.java)
+                    else -> null
+                }
+                if (event != null) {
+                    events.add(event)
+                }
+            }
+        }
+
+        private fun saveUpdatedList() {
+            // check if caching is enabled to update persistent data
+            if (InAppMessaging.instance().isLocalCachingEnabled()) {
+                // reset message list from cached using updated user info
+                InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(LOCAL_EVENT_KEY,
+                        Gson().toJson(events))?.apply()
+            }
         }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepository.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
 import androidx.annotation.WorkerThread
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 
 /**
@@ -27,21 +28,31 @@ internal interface LocalOptedOutMessageRepository {
 
     companion object {
         private var instance: LocalOptedOutMessageRepository = LocalOptedOutMessageRepositoryImpl()
+        private const val LOCAL_OPTED_OUT_KEY = "local_opted_out_list"
 
         fun instance() = instance
     }
 
     private class LocalOptedOutMessageRepositoryImpl : LocalOptedOutMessageRepository {
         private val optedOutMessages = HashSet<String?>()
+        private var user = ""
+
+        init {
+            checkAndResetSet(true)
+        }
 
         override fun addMessage(message: Message) {
             synchronized(optedOutMessages) {
+                checkAndResetSet()
                 optedOutMessages.add(message.getCampaignId())
+                saveUpdatedSet()
             }
         }
 
         override fun hasMessage(messageCampaignId: String?): Boolean {
             synchronized(optedOutMessages) {
+                // check if caching is enabled and if there are changes in user info
+                checkAndResetSet()
                 return optedOutMessages.contains(messageCampaignId)
             }
         }
@@ -49,6 +60,30 @@ internal interface LocalOptedOutMessageRepository {
         override fun clearMessages() {
             synchronized(optedOutMessages) {
                 optedOutMessages.clear()
+                saveUpdatedSet()
+            }
+        }
+
+        private fun checkAndResetSet(onLaunch: Boolean = false) {
+            // check if caching is enabled and if there are changes in user info
+            if (InAppMessaging.instance().isLocalCachingEnabled() &&
+                    (onLaunch || user != AccountRepository.instance().userInfoHash)) {
+                user = AccountRepository.instance().userInfoHash
+                optedOutMessages.clear()
+                // reset message list from cached using updated user info
+                InAppMessaging.instance().getEncryptedSharedPref()?.getStringSet(
+                        LOCAL_OPTED_OUT_KEY, HashSet<String?>())?.let {
+                    optedOutMessages.addAll(it)
+                }
+            }
+        }
+
+        private fun saveUpdatedSet() {
+            // check if caching is enabled to update persistent data
+            if (InAppMessaging.instance().isLocalCachingEnabled()) {
+                // reset message list from cached using updated user info
+                InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putStringSet(LOCAL_OPTED_OUT_KEY,
+                        optedOutMessages)?.apply()
             }
         }
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
@@ -1,7 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import com.google.gson.Gson
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.CampaignData
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
+import org.json.JSONObject
 
 /**
  * Contains all downloaded messages from Ping Message Mixer. Also exposed internal api which can get
@@ -13,6 +17,7 @@ internal abstract class PingResponseMessageRepository : MessageRepository {
 
     companion object {
         private var instance: PingResponseMessageRepository = PingResponseMessageRepositoryImpl()
+        private const val PING_RESPONSE_KEY = "ping_response_list"
 
         fun instance(): PingResponseMessageRepository = instance
     }
@@ -21,6 +26,11 @@ internal abstract class PingResponseMessageRepository : MessageRepository {
         // LinkedHashMap can preserve the message insertion order.
         // Map - Key: Campaign ID, Value: Message object
         private var messages: MutableMap<String, Message> = LinkedHashMap()
+        private var user = ""
+
+        init {
+            checkAndResetMap(true)
+        }
 
         /**
          * Replacing all new messages to the [messageList].
@@ -29,24 +39,70 @@ internal abstract class PingResponseMessageRepository : MessageRepository {
         @Throws(IllegalArgumentException::class)
         override fun replaceAllMessages(messageList: List<Message>?) {
             requireNotNull(messageList) { InAppMessagingConstants.ARGUMENT_IS_NULL_EXCEPTION }
-            messages = LinkedHashMap()
+            checkAndResetMap()
+
+            val localMap = LinkedHashMap<String, Message>()
             for (message in messageList) {
-                messages[message.getCampaignId()!!] = message
+                // max impression should not be updated
+                if (messages.containsKey(message.getCampaignId()!!)) {
+                    message.setMaxImpression(messages[message.getCampaignId()]?.getMaxImpressions()!!)
+                }
+                localMap[message.getCampaignId()!!] = message
             }
+            messages.clear()
+            messages.putAll(localMap)
+            saveUpdatedMap()
         }
 
         /**
          * This method returns a copy of all messages are in the current repository.
          */
-        override fun getAllMessagesCopy(): List<Message> = ArrayList(messages.values)
+        override fun getAllMessagesCopy(): List<Message> {
+            checkAndResetMap()
+            return ArrayList(messages.values)
+        }
 
         override fun clearMessages() {
             messages.clear()
+            saveUpdatedMap()
         }
 
         override fun incrementTimesClosed(messageList: List<Message>) {
+            checkAndResetMap()
             messages.filter { m -> messageList.any { it.getCampaignId() == m.key } }
                     .forEach { it.value.incrementTimesClosed() }
+            saveUpdatedMap()
+        }
+
+        private fun checkAndResetMap(onLaunch: Boolean = false) {
+            // check if caching is enabled and if there are changes in user info
+            if (InAppMessaging.instance().isLocalCachingEnabled() &&
+                    (onLaunch || user != AccountRepository.instance().userInfoHash)) {
+                user = AccountRepository.instance().userInfoHash
+                // reset message list from cached using updated user info
+                val listString = InAppMessaging.instance().getEncryptedSharedPref()?.getString(PING_RESPONSE_KEY, "")
+                        ?: ""
+                messages.clear()
+                if (listString.isNotEmpty()) {
+                    val jsonObject = JSONObject(listString)
+                    for (key in jsonObject.keys()) {
+                        val campaign = Gson().fromJson(
+                                jsonObject.getJSONObject(key).toString(), CampaignData::class.java)
+                        // manual setting since not part of constructor
+                        campaign.timesClosed = jsonObject.getJSONObject(key).getInt("timesClosed")
+                        messages[key] = campaign
+                    }
+                }
+            }
+        }
+
+        private fun saveUpdatedMap() {
+            // check if caching is enabled to update persistent data
+            if (InAppMessaging.instance().isLocalCachingEnabled()) {
+                // reset message list from cached using updated user info
+                InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(PING_RESPONSE_KEY,
+                        Gson().toJson(messages))?.apply()
+            }
         }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
@@ -1,7 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import com.google.gson.Gson
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.CampaignData
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
+import org.json.JSONArray
 
 /**
  * Contains all messages are ready for display, but not yet displayed.
@@ -10,6 +14,7 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
 
     companion object {
         private var instance: ReadyForDisplayMessageRepository = ReadyForDisplayMessageRepositoryImpl()
+        private const val READY_DISPLAY_KEY = "ready_display_list"
 
         fun instance(): ReadyForDisplayMessageRepository = instance
     }
@@ -17,6 +22,11 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
     private class ReadyForDisplayMessageRepositoryImpl : ReadyForDisplayMessageRepository() {
         // Oldest message should be displayed first, Deque offers the flexibility to add object to head or tail.
         private val messages: MutableList<Message> = ArrayList()
+        private var user = ""
+
+        init {
+            checkAndResetList(true)
+        }
 
         @Throws(IllegalArgumentException::class)
         override fun replaceAllMessages(messageList: List<Message>?) {
@@ -25,13 +35,19 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
             synchronized(messages) {
                 messages.clear()
                 messages.addAll(messageList)
+                saveUpdatedList()
             }
         }
 
-        override fun getAllMessagesCopy(): List<Message> = ArrayList(messages)
+        override fun getAllMessagesCopy(): List<Message> {
+            checkAndResetList()
+            return ArrayList(messages)
+        }
 
         override fun removeMessage(campaignId: String, shouldIncrementTimesClosed: Boolean) {
             synchronized(messages) {
+                // check if caching is enabled and if there are changes in user info
+                checkAndResetList()
                 messages.removeAll { message ->
                     if (message.getCampaignId() == campaignId) {
                         // messages contain unique message (no two message have the same campaign id)
@@ -43,6 +59,7 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
                         false
                     }
                 }
+                saveUpdatedList()
             }
         }
 
@@ -52,6 +69,33 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
                     PingResponseMessageRepository.instance().incrementTimesClosed(messages)
                 }
                 messages.clear()
+                saveUpdatedList()
+            }
+        }
+
+        private fun checkAndResetList(onLaunch: Boolean = false) {
+            if (InAppMessaging.instance().isLocalCachingEnabled() &&
+                    (onLaunch || user != AccountRepository.instance().userInfoHash)) {
+                user = AccountRepository.instance().userInfoHash
+                // reset message list from cached using updated user info
+                val listString = InAppMessaging.instance().getEncryptedSharedPref()?.getString(READY_DISPLAY_KEY, "")
+                        ?: ""
+                messages.clear()
+                if (listString.isNotEmpty()) {
+                    val jsonArray = JSONArray(listString)
+                    for (i in 0 until jsonArray.length()) {
+                        messages.add(Gson().fromJson(jsonArray.getJSONObject(i).toString(), CampaignData::class.java))
+                    }
+                }
+            }
+        }
+
+        private fun saveUpdatedList() {
+            // check if caching is enabled to update persistent data
+            if (InAppMessaging.instance().isLocalCachingEnabled()) {
+                // reset message list from cached using updated user info
+                InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(READY_DISPLAY_KEY,
+                        Gson().toJson(messages))?.apply()
             }
         }
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignData.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignData.kt
@@ -18,10 +18,11 @@ internal data class CampaignData(
     @SerializedName("isTest")
     private val isTest: Boolean,
     @SerializedName("maxImpressions")
-    private val maxImpressions: Int
+    private var maxImpressions: Int
 ) : Message {
 
-    private var timesQueued = 0
+    @SerializedName("timesClosed")
+    internal var timesClosed = 0
 
     override fun getType(): Int = type
 
@@ -35,18 +36,22 @@ internal data class CampaignData(
 
     override fun getMaxImpressions(): Int = maxImpressions
 
+    override fun setMaxImpression(maxImpression: Int) {
+        this.maxImpressions = maxImpression
+    }
+
     override fun getContexts(): List<String> {
         val regex = Regex("\\[(.*?)\\]")
         val matches = regex.findAll(messagePayload.title ?: "")
         return matches.map { it.groupValues[1] }.toList()
     }
 
-    override fun getNumberOfTimesClosed() = synchronized(timesQueued) {
-        timesQueued
+    override fun getNumberOfTimesClosed() = synchronized(timesClosed) {
+        timesClosed
     }
     override fun incrementTimesClosed() {
-        synchronized(timesQueued) {
-            timesQueued++
+        synchronized(timesClosed) {
+            timesClosed++
         }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
@@ -23,10 +23,11 @@ internal object EventsManager {
         eventScheduler: EventMessageReconciliationScheduler = EventMessageReconciliationScheduler.instance(),
         accountRepo: AccountRepository = AccountRepository.instance()
     ) {
+        val isUserUpdated = accountRepo.updateUserInfo()
         // Caching events locally.
         val isAdded = localEventRepo.addEvent(event)
         if (isAdded) {
-            if (accountRepo.updateUserInfo()) {
+            if (isUserUpdated) {
                 // Update session when there are updates in user info
                 // event reconciliation worker is already part of session update
                 SessionManager.onSessionUpdate(event)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/SessionManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/SessionManager.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.manager
 
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
@@ -18,25 +19,28 @@ internal object SessionManager {
      * user.
      */
     fun onSessionUpdate(event: Event? = null) {
-        // clear locally stored campaigns from ping response
-        PingResponseMessageRepository.instance().clearMessages()
+        if (!InAppMessaging.instance().isLocalCachingEnabled()) {
+            // clear locally stored campaigns from ping response
+            PingResponseMessageRepository.instance().clearMessages()
 
-        // clear locally stored campaigns which are ready for display
-        ReadyForDisplayMessageRepository.instance().clearMessages()
+            // clear locally stored campaigns which are ready for display
+            ReadyForDisplayMessageRepository.instance().clearMessages()
 
-        // clear locally stored campaigns which are already displayed
-        LocalDisplayedMessageRepository.instance().clearMessages()
+            // clear locally stored campaigns which are already displayed
+            LocalDisplayedMessageRepository.instance().clearMessages()
 
-        // clear locally stored campaigns which are opted out
-        LocalOptedOutMessageRepository.instance().clearMessages()
+            // clear locally stored campaigns which are opted out
+            LocalOptedOutMessageRepository.instance().clearMessages()
 
-        // clear locally stored triggered events (non-persistent)
-        LocalEventRepository.instance().clearNonPersistentEvents()
-        if (event != null && !event.isPersistentType()) {
-            // manually add latest event triggered by new user since it was removed from previous clearing
-            LocalEventRepository.instance().addEvent(event)
+            // clear locally stored triggered events (non-persistent)
+            LocalEventRepository.instance().clearNonPersistentEvents()
+            if (event != null && !event.isPersistentType()) {
+                // manually add latest event triggered by new user since it was removed from previous clearing
+                LocalEventRepository.instance().addEvent(event)
+            }
         }
 
+        // TODO: possibly add checking if the last ping is within a certain threshold before executing the request
         MessageMixerPingScheduler.instance().pingMessageMixerService(0)
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -108,7 +108,7 @@ internal object Initializer {
      */
     @SuppressWarnings("LongMethod")
     private fun getUuid(context: Context, sharedUtil: SharePreferencesUtil): String {
-        val sharedPref = sharedUtil.createSharedPreference(context, sharedUtil.generateKey(context))
+        val sharedPref = sharedUtil.createSharedPreference(context, sharedUtil.generateKey(context), "uuid")
 
         return if (sharedPref.contains(ID_KEY)) {
             sharedPref.getString(ID_KEY, "").toString()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/SharePreferencesUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/SharePreferencesUtil.kt
@@ -1,31 +1,17 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
 import android.content.Context
-import android.os.Build
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 
 internal object SharePreferencesUtil {
-    fun generateKey(context: Context) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        val spec = KeyGenParameterSpec.Builder(
-                MasterKey.DEFAULT_MASTER_KEY_ALIAS,
-                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setKeySize(MasterKey.DEFAULT_AES_GCM_MASTER_KEY_SIZE)
-                .build()
-        MasterKey.Builder(context).setKeyGenParameterSpec(spec).build()
-    } else {
-        MasterKey.Builder(context).build()
-    }
+    fun generateKey(context: Context) = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
 
-    fun createSharedPreference(context: Context, key: MasterKey) = EncryptedSharedPreferences.create(
-            context,
-            "shared_preferences",
-            key,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-    )
+    fun createSharedPreference(context: Context, key: MasterKey, account: String) = EncryptedSharedPreferences.create(
+                context,
+                account,
+                key,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/BaseTest.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/BaseTest.kt
@@ -1,12 +1,23 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime
 
 import org.junit.After
+import org.junit.BeforeClass
 import org.mockito.Mockito
+import org.robolectric.annotation.Config
 
 /**
  * Base test class of all test classes.
  */
+@Config(sdk = [22])
 open class BaseTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun beforeClass() {
+            TestKeyStore.setup
+        }
+    }
     /**
      * See [Memory leak in mockito-inline...](https://github.com/mockito/mockito/issues/1614)
      */

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -246,7 +246,7 @@ class InAppMessagingSpec : BaseTest() {
 
     @Test
     fun `should enable caching`() {
-        initializeInstance(false)
+        initializeInstance(true)
 
         InAppMessaging.instance().isLocalCachingEnabled().shouldBeTrue()
     }
@@ -261,13 +261,13 @@ class InAppMessagingSpec : BaseTest() {
         When calling viewGroup.tag itReturns "1"
     }
 
-    private fun initializeInstance(shouldDisableCaching: Boolean = false) {
+    private fun initializeInstance(shouldEnableCaching: Boolean = false) {
         WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
         Settings.Secure.putString(
                 ApplicationProvider.getApplicationContext<Context>().contentResolver,
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = true, isCacheHandling = !shouldDisableCaching)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = shouldEnableCaching)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -246,7 +246,7 @@ class InAppMessagingSpec : BaseTest() {
 
     @Test
     fun `should enable caching`() {
-        initializeInstance(true)
+        initializeInstance(false)
 
         InAppMessaging.instance().isLocalCachingEnabled().shouldBeTrue()
     }
@@ -268,6 +268,6 @@ class InAppMessagingSpec : BaseTest() {
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = !shouldDisableCaching)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = !shouldDisableCaching)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/TestKeyStore.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/TestKeyStore.kt
@@ -1,0 +1,85 @@
+package com.rakuten.tech.mobile.inappmessaging.runtime
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.*
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+import java.util.*
+import javax.crypto.KeyGenerator
+import javax.crypto.KeyGeneratorSpi
+import javax.crypto.SecretKey
+
+object TestKeyStore {
+
+    val setup by lazy {
+        Security.removeProvider("AndroidKeyStore")
+        Security.addProvider(BouncyCastleProvider())
+        Security.addProvider(object : Provider("AndroidKeyStore", 1.0, "") {
+            init {
+                put("KeyStore.AndroidKeyStore", MockKeyStore::class.java.name)
+                put("KeyGenerator.AES", MockAesKeyGenerator::class.java.name)
+            }
+        })
+    }
+
+    @Suppress("unused")
+    class MockKeyStore : KeyStoreSpi() {
+        private val wrapped = KeyStore.getInstance(KeyStore.getDefaultType())
+
+        override fun engineIsKeyEntry(alias: String?): Boolean = wrapped.isKeyEntry(alias)
+        override fun engineIsCertificateEntry(alias: String?): Boolean =
+            wrapped.isCertificateEntry(alias)
+
+        override fun engineGetCertificate(alias: String?): Certificate =
+            wrapped.getCertificate(alias)
+
+        override fun engineGetCreationDate(alias: String?): Date = wrapped.getCreationDate(alias)
+        override fun engineDeleteEntry(alias: String?) = wrapped.deleteEntry(alias)
+        override fun engineSetKeyEntry(
+            alias: String?,
+            key: Key?,
+            password: CharArray?,
+            chain: Array<out Certificate>?
+        ) =
+            wrapped.setKeyEntry(alias, key, password, chain)
+
+        override fun engineSetKeyEntry(
+            alias: String?,
+            key: ByteArray?,
+            chain: Array<out Certificate>?
+        ) = wrapped.setKeyEntry(alias, key, chain)
+
+        override fun engineStore(stream: OutputStream?, password: CharArray?) =
+            wrapped.store(stream, password)
+
+        override fun engineSize(): Int = wrapped.size()
+        override fun engineAliases(): Enumeration<String> = wrapped.aliases()
+        override fun engineContainsAlias(alias: String?): Boolean = wrapped.containsAlias(alias)
+        override fun engineLoad(stream: InputStream?, password: CharArray?) =
+            wrapped.load(stream, password)
+
+        override fun engineGetCertificateChain(alias: String?): Array<Certificate> =
+            wrapped.getCertificateChain(alias)
+
+        override fun engineSetCertificateEntry(alias: String?, cert: Certificate?) =
+            wrapped.setCertificateEntry(alias, cert)
+
+        override fun engineGetCertificateAlias(cert: Certificate?): String =
+            wrapped.getCertificateAlias(cert)
+
+        override fun engineGetKey(alias: String?, password: CharArray?): Key? =
+            wrapped.getKey(alias, password)
+    }
+
+    @Suppress("unused")
+    class MockAesKeyGenerator : KeyGeneratorSpi() {
+        private val wrapped = KeyGenerator.getInstance("AES")
+
+        override fun engineInit(random: SecureRandom?) = Unit
+        override fun engineInit(params: AlgorithmParameterSpec?, random: SecureRandom?) = Unit
+        override fun engineInit(keysize: Int, random: SecureRandom?) = Unit
+        override fun engineGenerateKey(): SecretKey = wrapped.generateKey()
+    }
+}

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/InvalidTestMessage.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/InvalidTestMessage.kt
@@ -15,6 +15,8 @@ internal class InvalidTestMessage : Message {
     override fun isTest(): Boolean = false
 
     override fun getMaxImpressions(): Int = 0
+    @SuppressWarnings("EmptyFunctionBlock")
+    override fun setMaxImpression(maxImpression: Int) {}
 
     override fun getContexts(): List<String> = listOf()
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/ValidTestMessage.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/messages/ValidTestMessage.kt
@@ -4,12 +4,16 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.InAppMessageTyp
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.MessagePayload
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigger
 
-internal class ValidTestMessage(var id: String = DEFAULT_CAMPAIGN_ID, private val isTest: Boolean = IS_TEST) : Message {
+internal class ValidTestMessage(
+    private val campaignId: String = DEFAULT_CAMPAIGN_ID,
+    private val isTest: Boolean = IS_TEST
+) : Message {
     internal var timesClosed = 0
+    private var max = 1
 
     override fun getType(): Int = InAppMessageType.MODAL.typeId
 
-    override fun getCampaignId() = id
+    override fun getCampaignId() = campaignId
 
     override fun getTriggers(): List<Trigger>? {
         val triggerList = ArrayList<Trigger>()
@@ -21,7 +25,11 @@ internal class ValidTestMessage(var id: String = DEFAULT_CAMPAIGN_ID, private va
 
     override fun isTest(): Boolean = isTest
 
-    override fun getMaxImpressions(): Int = 1
+    override fun getMaxImpressions() = max
+
+    override fun setMaxImpression(maxImpression: Int) {
+        this.max = maxImpression
+    }
 
     override fun getContexts(): List<String> = listOf()
 
@@ -42,7 +50,7 @@ internal class ValidTestMessage(var id: String = DEFAULT_CAMPAIGN_ID, private va
     }
 
     override fun hashCode(): Int {
-        var result = id.hashCode()
+        var result = campaignId.hashCode()
         result = 31 * result + isTest.hashCode()
         return result
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepositorySpec.kt
@@ -157,7 +157,7 @@ class AccountRepositorySpec : BaseTest() {
     }
 
     @Test
-    fun `should return true for changed rae token`() {
+    fun `should return false for changed rae token`() {
         val infoProvider = TestUserInfoProvider()
         AccountRepository.instance().userInfoProvider = infoProvider
         // initial setting of hashed user info
@@ -166,6 +166,6 @@ class AccountRepositorySpec : BaseTest() {
         // updated
         infoProvider.raeToken = "rae-token"
 
-        AccountRepository.instance().updateUserInfo().shouldBeTrue()
+        AccountRepository.instance().updateUserInfo().shouldBeFalse()
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -1,13 +1,10 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
-import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
-import com.rakuten.tech.mobile.inappmessaging.runtime.R
+import com.rakuten.tech.mobile.inappmessaging.runtime.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.coroutine.MessageActionsCoroutine
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.InvalidTestMessage
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
@@ -20,14 +17,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import kotlin.test.fail
 
 /**
  * Test class for LocalDisplayedMessageRepository.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LocalDisplayedMessageRepositorySpec : BaseTest() {
 
     @Before
@@ -111,5 +106,35 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
 
         LocalDisplayedMessageRepository.instance().addMessage(message)
         LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `should save and restore values for different users`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
+
+        val message = ValidTestMessage()
+        LocalDisplayedMessageRepository.instance().addMessage(message)
+        LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 1
+
+        infoProvider.rakutenId = "user2"
+        AccountRepository.instance().updateUserInfo()
+        LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
+
+        // revert to initial user info
+        infoProvider.rakutenId = TestUserInfoProvider.TEST_RAKUTEN_ID
+        AccountRepository.instance().updateUserInfo()
+        LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 1
+    }
+
+    private fun initializeInstance(infoProvider: UserInfoProvider) {
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        Settings.Secure.putString(
+                ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID,
+                "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
+                isDebugLogging = true, isForTesting = false)
+        InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -134,7 +134,7 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = false)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = true)
         InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
@@ -1,6 +1,13 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
+import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
@@ -10,11 +17,14 @@ import org.amshove.kluent.shouldHaveSize
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
 
 /**
  * Test class for LocalEventRepository.
  */
+@RunWith(RobolectricTestRunner::class)
 class LocalEventRepositorySpec : BaseTest() {
 
     @Before
@@ -76,11 +86,7 @@ class LocalEventRepositorySpec : BaseTest() {
 
     @Test
     fun `should contain correct number of event when adding multiple persistent types`() {
-        LocalEventRepository.instance().addEvent(AppStartEvent())
-        LocalEventRepository.instance().addEvent(AppStartEvent())
-        LocalEventRepository.instance().addEvent(LoginSuccessfulEvent())
-        LocalEventRepository.instance().addEvent(PurchaseSuccessfulEvent())
-        LocalEventRepository.instance().addEvent(CustomEvent("test"))
+        initializeLocalEvent()
         LocalEventRepository.instance().getEvents().shouldHaveSize(4)
     }
 
@@ -109,11 +115,7 @@ class LocalEventRepositorySpec : BaseTest() {
 
     @Test
     fun `should return valid value after clearing then adding`() {
-        LocalEventRepository.instance().addEvent(AppStartEvent())
-        LocalEventRepository.instance().addEvent(AppStartEvent())
-        LocalEventRepository.instance().addEvent(LoginSuccessfulEvent())
-        LocalEventRepository.instance().addEvent(PurchaseSuccessfulEvent())
-        LocalEventRepository.instance().addEvent(CustomEvent("test"))
+        initializeLocalEvent()
         LocalEventRepository.instance().getEvents().shouldHaveSize(4)
 
         LocalEventRepository.instance().clearNonPersistentEvents()
@@ -130,5 +132,42 @@ class LocalEventRepositorySpec : BaseTest() {
     fun `should not throw exception when clearing with empty events`() {
         LocalEventRepository.instance().clearNonPersistentEvents()
         LocalEventRepository.instance().getEvents().shouldHaveSize(0)
+    }
+
+    @Test
+    fun `should save and restore values for different users`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
+
+        initializeLocalEvent()
+        LocalEventRepository.instance().getEvents().shouldHaveSize(4)
+
+        infoProvider.rakutenId = "user2"
+        AccountRepository.instance().updateUserInfo()
+        LocalEventRepository.instance().getEvents().shouldHaveSize(1) // persistent type is retained
+
+        // revert to initial user info
+        infoProvider.rakutenId = TestUserInfoProvider.TEST_RAKUTEN_ID
+        AccountRepository.instance().updateUserInfo()
+        LocalEventRepository.instance().getEvents().shouldHaveSize(4)
+    }
+
+    private fun initializeInstance(infoProvider: UserInfoProvider) {
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        Settings.Secure.putString(
+                ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID,
+                "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
+                isDebugLogging = true, isForTesting = false)
+        InAppMessaging.instance().registerPreference(infoProvider)
+    }
+
+    private fun initializeLocalEvent() {
+        LocalEventRepository.instance().addEvent(AppStartEvent())
+        LocalEventRepository.instance().addEvent(AppStartEvent())
+        LocalEventRepository.instance().addEvent(LoginSuccessfulEvent())
+        LocalEventRepository.instance().addEvent(PurchaseSuccessfulEvent())
+        LocalEventRepository.instance().addEvent(CustomEvent("test"))
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
@@ -159,7 +159,7 @@ class LocalEventRepositorySpec : BaseTest() {
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = false)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = true)
         InAppMessaging.instance().registerPreference(infoProvider)
     }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepositorySpec.kt
@@ -77,7 +77,7 @@ class LocalOptedOutMessageRepositorySpec : BaseTest() {
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = false)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = true)
         InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepositorySpec.kt
@@ -1,14 +1,24 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
+import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.ValidTestMessage
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 /**
  * Test class for LocalOptedOutMessageRepository.
  */
+@RunWith(RobolectricTestRunner::class)
 class LocalOptedOutMessageRepositorySpec : BaseTest() {
     @Test
     fun `should add message correctly`() {
@@ -39,5 +49,35 @@ class LocalOptedOutMessageRepositorySpec : BaseTest() {
 
         LocalOptedOutMessageRepository.instance().addMessage(message)
         LocalOptedOutMessageRepository.instance().hasMessage(message.getCampaignId()).shouldBeTrue()
+    }
+
+    @Test
+    fun `should save and restore values for different users`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
+
+        val message = ValidTestMessage()
+        LocalOptedOutMessageRepository.instance().addMessage(message)
+        LocalOptedOutMessageRepository.instance().hasMessage(message.getCampaignId()).shouldBeTrue()
+
+        infoProvider.rakutenId = "user2"
+        AccountRepository.instance().updateUserInfo()
+        LocalOptedOutMessageRepository.instance().hasMessage(message.getCampaignId()).shouldBeFalse()
+
+        // revert to initial user info
+        infoProvider.rakutenId = TestUserInfoProvider.TEST_RAKUTEN_ID
+        AccountRepository.instance().updateUserInfo()
+        LocalOptedOutMessageRepository.instance().hasMessage(message.getCampaignId()).shouldBeTrue()
+    }
+
+    private fun initializeInstance(infoProvider: UserInfoProvider) {
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        Settings.Secure.putString(
+                ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID,
+                "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
+                isDebugLogging = true, isForTesting = false)
+        InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
@@ -1,18 +1,29 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
+import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.ValidTestMessage
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldHaveSize
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 /**
  * Test class for PingResponseMessageRepository.
  */
+@RunWith(RobolectricTestRunner::class)
 class PingResponseMessageRepositorySpec : BaseTest() {
     private val message0 = ValidTestMessage()
     private val message1 = ValidTestMessage("1234")
@@ -72,10 +83,12 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should increment all matching from single item`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         PingResponseMessageRepository.instance().incrementTimesClosed(listOf(message0))
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
-            if (msg.getCampaignId() != "1234") {
+            if (msg.getCampaignId() != message1.getCampaignId()) {
                 msg.getNumberOfTimesClosed() shouldBeEqualTo 1
             } else {
                 msg.getNumberOfTimesClosed() shouldBeEqualTo 0
@@ -99,5 +112,53 @@ class PingResponseMessageRepositorySpec : BaseTest() {
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
             msg.getNumberOfTimesClosed() shouldBeEqualTo 0
         }
+    }
+
+    @Test
+    fun `should save and restore values for different users`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
+
+        PingResponseMessageRepository.instance().replaceAllMessages(messageList)
+        PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+
+        infoProvider.rakutenId = "user2"
+        AccountRepository.instance().updateUserInfo()
+        PingResponseMessageRepository.instance().getAllMessagesCopy().shouldBeEmpty()
+
+        // revert to initial user info
+        infoProvider.rakutenId = TestUserInfoProvider.TEST_RAKUTEN_ID
+        AccountRepository.instance().updateUserInfo()
+        PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+    }
+
+    @Test
+    fun `should not update max impression`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
+
+        PingResponseMessageRepository.instance().replaceAllMessages(messageList)
+        PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getMaxImpressions() shouldBeEqualTo 1
+        }
+
+        message0.setMaxImpression(3)
+        PingResponseMessageRepository.instance().replaceAllMessages(listOf(message0))
+        PingResponseMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            msg.getMaxImpressions() shouldBeEqualTo 3
+        }
+    }
+
+    private fun initializeInstance(infoProvider: UserInfoProvider) {
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        Settings.Secure.putString(
+                ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID,
+                "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
+                isDebugLogging = true, isForTesting = false)
+        InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
@@ -158,7 +158,7 @@ class PingResponseMessageRepositorySpec : BaseTest() {
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = false)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = true)
         InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepositorySpec.kt
@@ -1,19 +1,27 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
+import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.ValidTestMessage
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
-import org.amshove.kluent.shouldBeEmpty
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.*
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 /**
  * Test class for ReadyForDisplayMessageRepository.
  */
+@RunWith(RobolectricTestRunner::class)
 class ReadyForDisplayMessageRepositorySpec : BaseTest() {
     private val messageList = ArrayList<Message>()
     private val message0 = ValidTestMessage()
@@ -123,5 +131,34 @@ class ReadyForDisplayMessageRepositorySpec : BaseTest() {
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
             msg.getNumberOfTimesClosed() shouldBeEqualTo 0
         }
+    }
+
+    @Test
+    fun `should save and restore values for different users`() {
+        val infoProvider = TestUserInfoProvider()
+        initializeInstance(infoProvider)
+
+        ReadyForDisplayMessageRepository.instance().replaceAllMessages(messageList)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+
+        infoProvider.rakutenId = "user2"
+        AccountRepository.instance().updateUserInfo()
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldBeEmpty()
+
+        // revert to initial user info
+        infoProvider.rakutenId = TestUserInfoProvider.TEST_RAKUTEN_ID
+        AccountRepository.instance().updateUserInfo()
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(2)
+    }
+
+    private fun initializeInstance(infoProvider: UserInfoProvider) {
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        Settings.Secure.putString(
+                ApplicationProvider.getApplicationContext<Context>().contentResolver,
+                Settings.Secure.ANDROID_ID,
+                "test_device_id")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
+                isDebugLogging = true, isForTesting = false)
+        InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepositorySpec.kt
@@ -158,7 +158,7 @@ class ReadyForDisplayMessageRepositorySpec : BaseTest() {
                 Settings.Secure.ANDROID_ID,
                 "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = false)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = true)
         InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManagerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.manager
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkManager
@@ -25,14 +24,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.concurrent.ExecutionException
 
 /**
  * Test class for EventsManager.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class EventsManagerSpec : BaseTest() {
 
     private val message = ValidTestMessage()

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/SessionManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/SessionManagerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.manager
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkManager
@@ -22,14 +21,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.concurrent.ExecutionException
 
 /**
  * Test class for SessionManager.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class SessionManagerSpec : BaseTest() {
 
     private var configResponseData = Mockito.mock(ConfigResponseData::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -65,7 +65,8 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
 
         Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
                 Settings.Secure.ANDROID_ID, "test_device_id")
-        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "")
+        InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "",
+                isForTesting = true)
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
     }
 


### PR DESCRIPTION
# Description
used encrypted shared preference (unique for each user) to save all the campaign and event repositories

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors