### PR TITLE
fix: move restoring of cached data before check if initial launch to prevent multiple app launch events

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -60,10 +60,10 @@ internal interface LocalEventRepository : EventRepository {
             require(!event.getEventName().isNullOrEmpty()) { InAppMessagingConstants.ARGUMENT_IS_EMPTY_EXCEPTION }
 
             synchronized(events) {
+                checkAndResetList()
                 // If persistent type, event should only be stored once.
                 if (shouldIgnore(event)) return false
 
-                checkAndResetList()
                 events.add(event)
                 Timber.tag(TAG).d(event.getEventName())
                 event.getAttributeMap().forEach { (key, value) ->


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors