### PR TITLE
fix: add cache handling for onVerifyContext and fix app launch campaign display behavior

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -6,7 +6,7 @@ import android.content.SharedPreferences
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingInitializationException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.Initializer
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.ConfigScheduler
@@ -128,8 +128,8 @@ abstract class InAppMessaging internal constructor() {
             // Initializing SDK using background worker thread.
             Initializer.initializeSdk(context, subscriptionKey, configUrl, isForTesting)
 
-            // inform event repository that it is initial launch to remove previously stored persistent event
-            LocalEventRepository.isInitialLaunch = true
+            // inform ping response repository that it is initial launch to display app launch campaign at least once
+            PingResponseMessageRepository.isInitialLaunch = true
 
             configScheduler.startConfig()
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -38,8 +38,6 @@ internal interface LocalEventRepository : EventRepository {
         private var instance: LocalEventRepository = LocalEventRepositoryImpl()
         private const val LOCAL_EVENT_KEY = "local_event_list"
 
-        internal var isInitialLaunch = false
-
         fun instance() = instance
     }
 
@@ -108,10 +106,6 @@ internal interface LocalEventRepository : EventRepository {
 
         private fun shouldIgnore(event: Event): Boolean {
             if (event.isPersistentType()) {
-                if (isInitialLaunch) {
-                    isInitialLaunch = false
-                    clearPersistentEvents()
-                }
                 for (currEvent in events) {
                     if (event.getEventType() == currEvent.getEventType() &&
                             event.getEventName() == currEvent.getEventName()) return true
@@ -119,14 +113,6 @@ internal interface LocalEventRepository : EventRepository {
             }
 
             return false
-        }
-
-        private fun clearPersistentEvents() {
-            synchronized(events) {
-                if (events.isNotEmpty()) {
-                    events.removeAll { ev -> ev.isPersistentType() }
-                }
-            }
         }
 
         private fun checkAndResetList(onLaunch: Boolean = false) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/MessageRepository.kt
@@ -30,4 +30,9 @@ internal interface MessageRepository {
      * for all the messages in the [messageList].
      */
     fun incrementTimesClosed(messageList: List<Message>)
+
+    /**
+     * Checks if campaign with only App Launch event should still be displayed.
+     */
+    fun shouldDisplayAppLaunchCampaign(id: String): Boolean
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
@@ -79,9 +79,8 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
             // Message display aborted by the host app
             Timber.tag(TAG).d("message display cancelled by the host app")
 
-            // Mark the message as displayed
-            localDisplayRepo.addMessage(message)
-            readyMessagesRepo.removeMessage(message.getCampaignId()!!)
+            // increment time closed to handle required number of events to be triggered
+            readyMessagesRepo.removeMessage(message.getCampaignId()!!, true)
 
             prepareNextMessage()
             return

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
@@ -8,6 +8,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Even
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigger
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.TriggerAttribute
 import timber.log.Timber
@@ -114,8 +115,10 @@ internal interface MessageEventReconciliationUtil {
                         // Add this event to eventsToBeRemoved list because it can't be used again
                         // to satisfy any more triggers.
                         if (event.isPersistentType()) {
-                            if (triggerList.size > 1) {
-                                // If campaign depends on other events other than a persistent type (i.e. App Launch),
+                            if (triggerList.size > 1 || PingResponseMessageRepository.instance()
+                                            .shouldDisplayAppLaunchCampaign(message.getCampaignId()!!)) {
+                                // If campaign depends on other events other than a persistent type (i.e. App Launch)
+                                // or should at least be displayed once,
                                 // no need to check the required number for satisfied triggers
                                 continue@triggers
                             }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepositorySpec.kt
@@ -24,6 +24,7 @@ import org.robolectric.RobolectricTestRunner
  * Test class for PingResponseMessageRepository.
  */
 @RunWith(RobolectricTestRunner::class)
+@SuppressWarnings("LargeClass")
 class PingResponseMessageRepositorySpec : BaseTest() {
     private val message0 = ValidTestMessage()
     private val message1 = ValidTestMessage("1234")
@@ -133,6 +134,8 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should return false when not first launch`() {
+        initializeInstance(TestUserInfoProvider(), false)
+        PingResponseMessageRepository.isInitialLaunch = false
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
             PingResponseMessageRepository.instance()
@@ -142,6 +145,7 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should return true when first launch`() {
+        initializeInstance(TestUserInfoProvider(), false)
         PingResponseMessageRepository.isInitialLaunch = true
         PingResponseMessageRepository.instance().replaceAllMessages(messageList)
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
@@ -152,6 +156,7 @@ class PingResponseMessageRepositorySpec : BaseTest() {
 
     @Test
     fun `should return true to app launch only and false to multiple triggers`() {
+        initializeInstance(TestUserInfoProvider(), false)
         PingResponseMessageRepository.isInitialLaunch = true
         val mockMessage = Mockito.mock(Message::class.java)
         When calling mockMessage.getCampaignId() itReturns "54321"
@@ -187,12 +192,12 @@ class PingResponseMessageRepositorySpec : BaseTest() {
         }
     }
 
-    private fun initializeInstance(infoProvider: UserInfoProvider) {
+    private fun initializeInstance(infoProvider: UserInfoProvider, isCache: Boolean = true) {
         WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
         Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
                 Settings.Secure.ANDROID_ID, "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
-                isDebugLogging = true, isForTesting = true, isCacheHandling = true)
+                isDebugLogging = true, isForTesting = true, isCacheHandling = isCache)
         InAppMessaging.instance().registerPreference(infoProvider)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -14,6 +14,7 @@ import com.facebook.soloader.SoLoader
 import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.never
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
@@ -212,7 +213,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
     }
 
     @Test
-    fun `should add message to LocalDisplayedMessageRepository when its context was rejected`() {
+    fun `should not add message to LocalDisplayedMessageRepository when its context was rejected`() {
         val message = Mockito.mock(Message::class.java)
 
         When calling onVerifyContexts.invoke(any(), any()) itReturns false
@@ -227,10 +228,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns message itReturns null
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        argumentCaptor<Message>().apply {
-            Mockito.verify(mockLocalDisplayRepo, Mockito.times(1)).addMessage(capture())
-            firstValue shouldBeEqualTo message
-        }
+        Mockito.verify(mockLocalDisplayRepo, never()).addMessage(any())
     }
 
     @Test
@@ -250,7 +248,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         argumentCaptor<String>().apply {
-            Mockito.verify(mockReadyForDisplayRepo, Mockito.times(1)).removeMessage(capture(), eq(false))
+            Mockito.verify(mockReadyForDisplayRepo, Mockito.times(1)).removeMessage(capture(), eq(true))
             firstValue shouldBeEqualTo message.getCampaignId()
         }
     }


### PR DESCRIPTION
# Description
if `onVerifyContext` returns false, the times closed for campaign is increased to have the correct count of required number of events trigger without incrementing the campaign's impression

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors