### PR TITLE
fix: add handling for closed campaign when app is killed

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
@@ -59,7 +60,8 @@ internal class InApp(
 
     @Suppress("FunctionMaxLength")
     override fun unregisterMessageDisplayActivity() {
-        displayManager.removeMessage(getRegisteredActivity())
+        val id = displayManager.removeMessage(getRegisteredActivity())
+        LocalDisplayedMessageRepository.instance().setRemovedMessage(id as String?)
         activityWeakReference?.clear()
 
         Timber.tag(TAG)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingInitializationException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.Initializer
@@ -130,6 +131,7 @@ abstract class InAppMessaging internal constructor() {
 
             // inform ping response repository that it is initial launch to display app launch campaign at least once
             PingResponseMessageRepository.isInitialLaunch = true
+            LocalDisplayedMessageRepository.isInitialLaunch = true
 
             configScheduler.startConfig()
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutine.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutine.kt
@@ -66,6 +66,7 @@ internal class MessageActionsCoroutine(
 
         // Adding message to LocalDisplayedMessageRepository.
         localDisplayRepo.addMessage(message)
+        localDisplayRepo.setRemovedMessage("")
 
         // If message is opted out, add it to LocalOptedOutMessageRepository.
         if (optOut) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -25,10 +25,20 @@ internal interface LocalDisplayedMessageRepository {
     fun addMessage(message: Message?)
 
     /**
+     * Sets the last message campaign ID in the repository which was closed after unregistering activity.
+     */
+    fun setRemovedMessage(id: String?)
+
+    /**
      * Return the number of times this message has been displayed in this session.
      * When message is null or message's campaignId is empty, return 0.
      */
     fun numberOfTimesDisplayed(message: Message): Int
+
+    /**
+     * Returns the number of times the campaign ID was closed after unregistering activity.
+     */
+    fun numberOfTimesClosed(id: String): Int
 
     /**
      * This method removes all stored messages.
@@ -39,7 +49,11 @@ internal interface LocalDisplayedMessageRepository {
     companion object {
         private var instance: LocalDisplayedMessageRepository = LocalDisplayedMessageRepositoryImpl()
         private const val LOCAL_DISPLAYED_KEY = "local_displayed_list"
+        private const val LOCAL_DISPLAYED_CLOSED_KEY = "local_displayed_closed"
+        private const val LOCAL_DISPLAYED_CLOSED_LIST_KEY = "local_displayed_closed_list"
         private const val TAG = "IAM_LocalEventRepo"
+
+        internal var isInitialLaunch = false
 
         fun instance() = instance
     }
@@ -49,6 +63,8 @@ internal interface LocalDisplayedMessageRepository {
         // Such as:
         // {5bf41c52-e4c0-4cb2-9183-df429e84d681, [1537309879557,1537309879557,1537309879557]}
         private val messages = HashMap<String, List<Long>>()
+        private val removedMessages = HashMap<String, Int>()
+        private var removedMessage = ""
         private var user = ""
 
         init {
@@ -80,6 +96,26 @@ internal interface LocalDisplayedMessageRepository {
             }
         }
 
+        override fun setRemovedMessage(id: String?) {
+            checkAndResetMap()
+            removedMessage = id ?: ""
+            saveUpdatedMap()
+        }
+
+        override fun numberOfTimesClosed(id: String): Int {
+            synchronized(removedMessages) {
+                if (isInitialLaunch && removedMessage.isNotEmpty()) {
+                    isInitialLaunch = false
+                    // only increment if campaign is removed then relaunch
+                    removedMessages[removedMessage] = removedMessages.getOrElse(removedMessage) { 0 } + 1
+                    saveUpdatedMap()
+                } else {
+                    checkAndResetMap()
+                }
+                return removedMessages[id] ?: 0
+            }
+        }
+
         override fun numberOfTimesDisplayed(message: Message): Int {
             synchronized(messages) {
                 checkAndResetMap()
@@ -90,25 +126,35 @@ internal interface LocalDisplayedMessageRepository {
         }
 
         override fun clearMessages() {
-            if (messages.isNotEmpty()) {
-                messages.clear()
-                saveUpdatedMap()
-            }
+            messages.clear()
+            removedMessages.clear()
+            removedMessage = ""
+            saveUpdatedMap()
         }
 
+        @SuppressWarnings("LongMethod")
         private fun checkAndResetMap(onLaunch: Boolean = false) {
             // check if caching is enabled and if there are changes in user info
             if (InAppMessaging.instance().isLocalCachingEnabled() &&
                     (onLaunch || user != AccountRepository.instance().userInfoHash)) {
                 user = AccountRepository.instance().userInfoHash
                 // reset message list from cached using updated user info
-                val listString = InAppMessaging.instance().getEncryptedSharedPref()?.getString(LOCAL_DISPLAYED_KEY, "")
-                        ?: ""
+                val sharedPref = InAppMessaging.instance().getEncryptedSharedPref()
+                val listString = sharedPref?.getString(LOCAL_DISPLAYED_KEY, "") ?: ""
                 messages.clear()
                 if (listString.isNotEmpty()) {
                     val type = object : TypeToken<HashMap<String, List<Long>>>() {}.type
                     messages.putAll(Gson().fromJson(listString, type))
                 }
+
+                val removedList = sharedPref?.getString(LOCAL_DISPLAYED_CLOSED_LIST_KEY, "") ?: ""
+                removedMessages.clear()
+                if (removedList.isNotEmpty()) {
+                    val type = object : TypeToken<HashMap<String, Int>>() {}.type
+                    removedMessages.putAll(Gson().fromJson(removedList, type))
+                }
+
+                removedMessage = sharedPref?.getString(LOCAL_DISPLAYED_CLOSED_KEY, "") ?: ""
             }
         }
 
@@ -116,8 +162,11 @@ internal interface LocalDisplayedMessageRepository {
             // check if caching is enabled to update persistent data
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
                 // reset message list from cached using updated user info
-                InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(LOCAL_DISPLAYED_KEY,
-                        Gson().toJson(messages))?.apply() ?: Timber.tag(TAG).d("failed saving map")
+                val editor = InAppMessaging.instance().getEncryptedSharedPref()?.edit()
+                editor?.putString(LOCAL_DISPLAYED_KEY, Gson().toJson(messages))
+                        ?.putString(LOCAL_DISPLAYED_CLOSED_KEY, removedMessage)
+                        ?.putString(LOCAL_DISPLAYED_CLOSED_LIST_KEY, Gson().toJson(removedMessages))
+                        ?.apply() ?: Timber.tag(TAG).d("failed saving displayed data")
             }
         }
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -120,7 +120,7 @@ internal interface LocalEventRepository : EventRepository {
             if (InAppMessaging.instance().isLocalCachingEnabled() &&
                     (onLaunch || user != AccountRepository.instance().userInfoHash)) {
                 user = AccountRepository.instance().userInfoHash
-                // reset message list from cached using updated user info
+                // reset event list from cached using updated user info
                 val listString = InAppMessaging.instance().getEncryptedSharedPref()?.getString(LOCAL_EVENT_KEY, "")
                         ?: ""
                 if (listString.isNotEmpty()) {
@@ -155,7 +155,7 @@ internal interface LocalEventRepository : EventRepository {
         private fun saveUpdatedList() {
             // check if caching is enabled to update persistent data
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
-                // reset message list from cached using updated user info
+                // save updated event list
                 InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(LOCAL_EVENT_KEY,
                         Gson().toJson(events))?.apply()
             }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepository.kt
@@ -70,7 +70,7 @@ internal interface LocalOptedOutMessageRepository {
                     (onLaunch || user != AccountRepository.instance().userInfoHash)) {
                 user = AccountRepository.instance().userInfoHash
                 optedOutMessages.clear()
-                // reset message list from cached using updated user info
+                // reset id list from cached using updated user info
                 InAppMessaging.instance().getEncryptedSharedPref()?.getStringSet(
                         LOCAL_OPTED_OUT_KEY, HashSet<String?>())?.let {
                     optedOutMessages.addAll(it)
@@ -81,7 +81,7 @@ internal interface LocalOptedOutMessageRepository {
         private fun saveUpdatedSet() {
             // check if caching is enabled to update persistent data
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
-                // reset message list from cached using updated user info
+                // save updated id list
                 InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putStringSet(LOCAL_OPTED_OUT_KEY,
                         optedOutMessages)?.apply()
             }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
@@ -107,7 +107,7 @@ internal abstract class PingResponseMessageRepository : MessageRepository {
         private fun saveUpdatedMap() {
             // check if caching is enabled to update persistent data
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
-                // reset message list from cached using updated user info
+                // save updated message list
                 InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(PING_RESPONSE_KEY,
                         Gson().toJson(messages))?.apply()
             }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
@@ -93,7 +93,7 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
         private fun saveUpdatedList() {
             // check if caching is enabled to update persistent data
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
-                // reset message list from cached using updated user info
+                // reset updated message list
                 InAppMessaging.instance().getEncryptedSharedPref()?.edit()?.putString(READY_DISPLAY_KEY,
                         Gson().toJson(messages))?.apply()
             }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
@@ -261,12 +261,14 @@ internal interface MessageEventReconciliationUtil {
         private fun getNumTimesToSatisfyTriggersForDisplay(message: Message): Int {
             val maxImpression = message.getMaxImpressions()
             val displayedImpression: Int = LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message)
+            val incrementRemoved = LocalDisplayedMessageRepository.instance()
+                    .numberOfTimesClosed(message.getCampaignId()!!)
 
             // Only check for message has been displayed less than its max impressions.
             // The number of times the message was removed from ready for display repository is considered since local
             // event list was not cleared and the triggers should  all be satisfied again.
             return if (maxImpression != null && displayedImpression < maxImpression) {
-                displayedImpression + 1 + message.getNumberOfTimesClosed()
+                displayedImpression + 1 + message.getNumberOfTimesClosed() + incrementRemoved
             } else 0
         }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
@@ -111,7 +111,8 @@ class ConfigWorkerSpec : BaseTest() {
         val version = ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName
         When calling mockHostRespository.getVersion() itReturns version
         When calling mockHostRespository.getConfigUrl() itReturns bundle.getString(CONFIG_KEY, "")
-        When calling mockHostRespository.getInAppMessagingSubscriptionKey() itReturns bundle.getString(SUBSCRIPTION_KEY, "")
+        When calling mockHostRespository
+                .getInAppMessagingSubscriptionKey() itReturns bundle.getString(SUBSCRIPTION_KEY, "")
         val worker = ConfigWorker(context, workerParameters, mockHostRespository, mockConfigRespository,
                 mockMessageScheduler)
         val expected = if (HostAppInfoRepository.instance().getConfigUrl().isNullOrEmpty())


### PR DESCRIPTION
# Description
When app is killed while a campaign is displayed, all triggered events are still cached. On next app launch, the campaign will still be displayed since all required events were still triggered from cached data.
To handle this behavior, a new counter is introduced to know the number of times the campaign is closed due to app being killed.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors