### PR TITLE
fix: add synchronization for non-map cache data, and change map to concurrent map

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepository.kt
@@ -10,6 +10,8 @@ import java.security.MessageDigest
  */
 internal abstract class AccountRepository {
     var userInfoProvider: UserInfoProvider? = null
+
+    @get:Synchronized @set:Synchronized
     internal var userInfoHash = ""
 
     /**

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Messa
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
 import timber.log.Timber
 import java.util.Calendar
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.collections.set
@@ -62,8 +63,8 @@ internal interface LocalDisplayedMessageRepository {
         // Displayed message campaign ID and a list of the epoch time in UTC this message was displayed.
         // Such as:
         // {5bf41c52-e4c0-4cb2-9183-df429e84d681, [1537309879557,1537309879557,1537309879557]}
-        private val messages = HashMap<String, List<Long>>()
-        private val removedMessages = HashMap<String, Int>()
+        private val messages = ConcurrentHashMap<String, List<Long>>()
+        private val removedMessages = ConcurrentHashMap<String, Int>()
         private var removedMessage = ""
         private var user = ""
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -46,7 +46,9 @@ internal interface LocalEventRepository : EventRepository {
         private var user = ""
 
         init {
-            checkAndResetList(true)
+            synchronized(events) {
+                checkAndResetList(true)
+            }
         }
 
         /**

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalOptedOutMessageRepository.kt
@@ -38,7 +38,9 @@ internal interface LocalOptedOutMessageRepository {
         private var user = ""
 
         init {
-            checkAndResetSet(true)
+            synchronized(optedOutMessages) {
+                checkAndResetSet(true)
+            }
         }
 
         override fun addMessage(message: Message) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/PingResponseMessageRepository.kt
@@ -6,6 +6,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Messa
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.CampaignData
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
 import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Contains all downloaded messages from Ping Message Mixer. Also exposed internal api which can get
@@ -27,8 +28,8 @@ internal abstract class PingResponseMessageRepository : MessageRepository {
     private class PingResponseMessageRepositoryImpl : PingResponseMessageRepository() {
         // LinkedHashMap can preserve the message insertion order.
         // Map - Key: Campaign ID, Value: Message object
-        private var messages: MutableMap<String, Message> = LinkedHashMap()
-        private var appLaunchList: MutableMap<String, Boolean> = LinkedHashMap()
+        private var messages: MutableMap<String, Message> = ConcurrentHashMap()
+        private var appLaunchList: MutableMap<String, Boolean> = ConcurrentHashMap()
         private var user = ""
 
         init {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/ReadyForDisplayMessageRepository.kt
@@ -25,7 +25,9 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
         private var user = ""
 
         init {
-            checkAndResetList(true)
+            synchronized(messages) {
+                checkAndResetList(true)
+            }
         }
 
         @Throws(IllegalArgumentException::class)
@@ -40,8 +42,10 @@ internal abstract class ReadyForDisplayMessageRepository : ReadyMessageRepositor
         }
 
         override fun getAllMessagesCopy(): List<Message> {
-            checkAndResetList()
-            return ArrayList(messages)
+            synchronized(messages) {
+                checkAndResetList()
+                return ArrayList(messages)
+            }
         }
 
         override fun removeMessage(campaignId: String, shouldIncrementTimesClosed: Boolean) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
@@ -20,6 +20,7 @@ internal object EventsManager {
      * This method adds logEvent on the events list.
      * Then starts session update and event worker to process that logEvent.
      */
+    @SuppressWarnings("onEventReceived")
     fun onEventReceived(
         event: Event,
         sendEvent: (String, Map<String, *>?) -> Unit = LegacyEventBroadcasterHelper::sendEvent,


### PR DESCRIPTION
# Description
To avoid `ConcurrentModificationException`, changed `LinkedHashMap` to `ConcurrentHashMap`.
For other cache data (non-map), add synchronization to be thread-safe.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors