### PR TITLE
feat: add disabled config handling for register/unregister activity, and logging events

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -24,7 +24,8 @@ internal class InApp(
     private val context: Context,
     isDebugLogging: Boolean,
     private val displayManager: DisplayManager = DisplayManager.instance(),
-    private var isCacheHandling: Boolean = BuildConfig.IS_CACHE_HANDLING
+    private var isCacheHandling: Boolean = BuildConfig.IS_CACHE_HANDLING,
+    private val eventsManager: EventsManager = EventsManager
 ) : InAppMessaging() {
 
     // Used for displaying or removing messages from screen.
@@ -60,19 +61,27 @@ internal class InApp(
 
     @Suppress("FunctionMaxLength")
     override fun unregisterMessageDisplayActivity() {
-        val id = displayManager.removeMessage(getRegisteredActivity())
-        LocalDisplayedMessageRepository.instance().setRemovedMessage(id as String?)
+        if (ConfigResponseRepository.instance().isConfigEnabled()) {
+            val id = displayManager.removeMessage(getRegisteredActivity())
+            LocalDisplayedMessageRepository.instance().setRemovedMessage(id as String?)
+        }
         activityWeakReference?.clear()
 
         Timber.tag(TAG)
         Timber.d("unregisterMessageDisplayActivity()")
     }
 
-    override fun logEvent(event: Event) = EventsManager.onEventReceived(event)
+    override fun logEvent(event: Event) {
+        if (ConfigResponseRepository.instance().isConfigEnabled()) {
+            eventsManager.onEventReceived(event)
+        }
+    }
 
     override fun updateSession() {
-        // Updates the current session to update all locally stored messages
-        SessionManager.onSessionUpdate()
+        if (ConfigResponseRepository.instance().isConfigEnabled()) {
+            // Updates the current session to update all locally stored messages
+            SessionManager.onSessionUpdate()
+        }
     }
 
     // ------------------------------------Library Internal APIs-------------------------------------

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -8,6 +8,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Even
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
@@ -30,6 +31,9 @@ internal class InApp(
 
     // Used for displaying or removing messages from screen.
     private var activityWeakReference: WeakReference<Activity>? = null
+
+    @VisibleForTesting
+    internal var tempEventList = ArrayList<Event>()
 
     init {
         if (isDebugLogging) {
@@ -74,6 +78,10 @@ internal class InApp(
     override fun logEvent(event: Event) {
         if (ConfigResponseRepository.instance().isConfigEnabled()) {
             eventsManager.onEventReceived(event)
+        } else {
+            synchronized(tempEventList) {
+                tempEventList.add(event)
+            }
         }
     }
 
@@ -81,6 +89,15 @@ internal class InApp(
         if (ConfigResponseRepository.instance().isConfigEnabled()) {
             // Updates the current session to update all locally stored messages
             SessionManager.onSessionUpdate()
+        }
+    }
+
+    override fun closeMessage(clearQueuedCampaigns: Boolean) {
+        if (ConfigResponseRepository.instance().isConfigEnabled()) {
+            CoroutineScope(Dispatchers.Main).launch {
+                // called inside main dispatcher to make sure that it is always called in UI thread
+                removeMessage(clearQueuedCampaigns)
+            }
         }
     }
 
@@ -96,10 +113,10 @@ internal class InApp(
     override fun getEncryptedSharedPref() = SharePreferencesUtil.createSharedPreference(context,
             SharePreferencesUtil.generateKey(context), AccountRepository.instance().userInfoHash)
 
-    override fun closeMessage(clearQueuedCampaigns: Boolean) {
-        CoroutineScope(Dispatchers.Main).launch {
-            // called inside main dispatcher to make sure that it is always called in UI thread
-            removeMessage(clearQueuedCampaigns)
+    override fun saveTempData() {
+        synchronized(tempEventList) {
+            tempEventList.forEach { LocalEventRepository.instance().addEvent(it) }
+            tempEventList.clear()
         }
     }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
@@ -18,7 +17,7 @@ import org.jetbrains.annotations.Nullable
  * Main entry point for the IAM SDK.
  * Should be accessed via [InAppMessaging.instance].
  */
-@Suppress("UnnecessaryAbstractClass")
+@Suppress("UnnecessaryAbstractClass", "TooManyFunctions")
 abstract class InAppMessaging internal constructor() {
     /**
      * This callback is called just before showing a message of campaign that has registered contexts.
@@ -90,6 +89,12 @@ abstract class InAppMessaging internal constructor() {
     internal abstract fun getEncryptedSharedPref(): SharedPreferences?
 
     /**
+     * This method moves temp data to persistent cache.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    internal abstract fun saveTempData()
+
+    /**
      * Close the currently displayed message.
      * This should be called when app needs to force-close the displayed message without user action.
      * Calling this method will not increment the campaign impression.
@@ -136,13 +141,12 @@ abstract class InAppMessaging internal constructor() {
             configScheduler.startConfig()
         }
 
-        @VisibleForTesting
         internal fun setUninitializedInstance() {
             instance = NotInitializedInAppMessaging()
         }
     }
 
-    @Suppress("EmptyFunctionBlock")
+    @Suppress("EmptyFunctionBlock", "TooManyFunctions")
     internal class NotInitializedInAppMessaging : InAppMessaging() {
         override var onVerifyContext: (contexts: List<String>, campaignTitle: String) -> Boolean = { _, _ -> true }
 
@@ -166,5 +170,7 @@ abstract class InAppMessaging internal constructor() {
         override fun getEncryptedSharedPref(): SharedPreferences? = null
 
         override fun closeMessage(clearQueuedCampaigns: Boolean) {}
+
+        override fun saveTempData() {}
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
@@ -20,7 +20,7 @@ internal object EventsManager {
      * This method adds logEvent on the events list.
      * Then starts session update and event worker to process that logEvent.
      */
-    @SuppressWarnings("onEventReceived")
+    @SuppressWarnings("LongMethod")
     fun onEventReceived(
         event: Event,
         sendEvent: (String, Map<String, *>?) -> Unit = LegacyEventBroadcasterHelper::sendEvent,

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorker.kt
@@ -90,6 +90,7 @@ internal class ConfigWorker(
             // Schedule a ping request to message mixer. Initial delay is 0
             // reset current delay to initial
             ConfigScheduler.currDelay = RetryDelayUtil.INITIAL_BACKOFF_DELAY
+            MessageMixerPingScheduler.currDelay = RetryDelayUtil.INITIAL_BACKOFF_DELAY
             messagePingScheduler.pingMessageMixerService(0)
             Timber.tag(TAG).d("Config Response: %d (%b)",
                     response.body()?.data?.rollOutPercentage, configRepo.isConfigEnabled())

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepositorySpec.kt
@@ -95,7 +95,7 @@ class AccountRepositorySpec : BaseTest() {
         val worker = ImpressionWorker(context, workerParameters)
         worker.createReportImpressionCall("https://host/impression/", impressionRequest,
                 accountRepo = mockAcctRepo)
-        Mockito.verify(mockAcctRepo, Mockito.times(1)).getRaeToken()
+        Mockito.verify(mockAcctRepo).getRaeToken()
     }
 
     @Test
@@ -106,7 +106,7 @@ class AccountRepositorySpec : BaseTest() {
         When calling mockAcctRepo.getUserId() itReturns TestUserInfoProvider().provideUserId().toString()
         When calling mockAcctRepo.getRakutenId() itReturns ""
         RuntimeUtil.getUserIdentifiers(mockAcctRepo).shouldHaveSize(1)
-        Mockito.verify(mockAcctRepo, Mockito.times(1)).getUserId()
+        Mockito.verify(mockAcctRepo).getUserId()
     }
 
     @Test
@@ -117,7 +117,7 @@ class AccountRepositorySpec : BaseTest() {
         When calling mockAcctRepo.getUserId() itReturns ""
         When calling mockAcctRepo.getRakutenId() itReturns TestUserInfoProvider().provideRakutenId().toString()
         RuntimeUtil.getUserIdentifiers(mockAcctRepo).shouldHaveSize(1)
-        Mockito.verify(mockAcctRepo, Mockito.times(1)).getRakutenId()
+        Mockito.verify(mockAcctRepo).getRakutenId()
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -82,7 +82,7 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
         When calling message.getCampaignId() itReturns "id"
         MessageActionsCoroutine(mockRepo).executeTask(message, R.id.message_close_button, true)
 
-        Mockito.verify(mockRepo, Mockito.times(1)).addMessage(message)
+        Mockito.verify(mockRepo).addMessage(message)
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
@@ -60,7 +60,7 @@ class LocalEventRepositorySpec : BaseTest() {
 
         EventsManager.onEventReceived(mockEvent, localEventRepo = mockRepo, eventScheduler = mockSched)
 
-        Mockito.verify(mockRepo, Mockito.times(1)).addEvent(mockEvent)
+        Mockito.verify(mockRepo).addEvent(mockEvent)
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -122,8 +122,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        Mockito.verify(onVerifyContexts, Mockito.times(1))
-                .invoke(listOf("ctx"), "Campaign Title")
+        Mockito.verify(onVerifyContexts).invoke(listOf("ctx"), "Campaign Title")
     }
 
     @Test
@@ -142,8 +141,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        Mockito.verify(onVerifyContexts, Mockito.times(0))
-                .invoke(any(), any())
+        Mockito.verify(onVerifyContexts, never()).invoke(any(), any())
     }
 
     @Test
@@ -162,8 +160,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        Mockito.verify(onVerifyContexts, Mockito.times(0))
-                .invoke(any(), any())
+        Mockito.verify(onVerifyContexts, never()).invoke(any(), any())
     }
 
     @SuppressWarnings("LongMethod")
@@ -248,7 +245,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
         argumentCaptor<String>().apply {
-            Mockito.verify(mockReadyForDisplayRepo, Mockito.times(1)).removeMessage(capture(), eq(true))
+            Mockito.verify(mockReadyForDisplayRepo).removeMessage(capture(), eq(true))
             firstValue shouldBeEqualTo message.getCampaignId()
         }
     }
@@ -266,8 +263,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns message
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        Mockito.verify(activity, Mockito.times(1))
-                .findViewById<View?>(ArgumentMatchers.anyInt())
+        Mockito.verify(activity).findViewById<View?>(ArgumentMatchers.anyInt())
     }
 
     @Test
@@ -294,8 +290,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         When calling mockMessageManager.getNextDisplayMessage() itReturns null
         displayMessageJobIntentService!!.onHandleWork(intent!!)
 
-        Mockito.verify(activity, Mockito.times(0))
-                .findViewById<View?>(ArgumentMatchers.anyInt())
+        Mockito.verify(activity, never()).findViewById<View?>(ArgumentMatchers.anyInt())
     }
 
     companion object {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentServiceSpec.kt
@@ -18,8 +18,10 @@ import com.nhaarman.mockitokotlin2.never
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.config.ConfigResponseData
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.CampaignData
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.MessagePayload
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
@@ -52,6 +54,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
     private var mockLocalDisplayRepo = Mockito.mock(LocalDisplayedMessageRepository::class.java)
     private var mockReadyForDisplayRepo = Mockito.mock(ReadyForDisplayMessageRepository::class.java)
     private val onVerifyContexts = Mockito.mock(InAppMessaging.instance().onVerifyContext.javaClass)
+    private val configResponseData = Mockito.mock(ConfigResponseData::class.java)
 
     @Before
     fun setup() {
@@ -64,6 +67,9 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
         WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
         When calling activity.layoutInflater itReturns LayoutInflater.from(ApplicationProvider.getApplicationContext())
 
+        When calling configResponseData.rollOutPercentage itReturns 100
+        ConfigResponseRepository.instance().addConfigResponse(configResponseData)
+
         Settings.Secure.putString(ApplicationProvider.getApplicationContext<Context>().contentResolver,
                 Settings.Secure.ANDROID_ID, "test_device_id")
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test-key", "",
@@ -73,6 +79,7 @@ class DisplayMessageJobIntentServiceSpec : BaseTest() {
 
     @After
     fun tearDown() {
+        ConfigResponseRepository.resetInstance()
         serviceController!!.destroy()
         validateMockitoUsage()
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
@@ -286,8 +286,8 @@ class MessageEventReconciliationUtilReconcileSpec : MessageEventReconciliationUt
                 mockPingRepo, mockReconUtil)
         worker.doWork()
 
-        Mockito.verify(mockReconUtil, Mockito.times(1)).extractTestMessages(messageList)
-        Mockito.verify(mockReconUtil, Mockito.times(1)).reconcileMessagesAndEvents(messageList)
+        Mockito.verify(mockReconUtil).extractTestMessages(messageList)
+        Mockito.verify(mockReconUtil).reconcileMessagesAndEvents(messageList)
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
@@ -30,7 +30,7 @@ import kotlin.collections.ArrayList
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
-@Ignore
+@Ignore("base class")
 open class MessageEventReconciliationUtilSpec : BaseTest() {
 
     val appStartEvent = AppStartEvent()

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListenerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListenerSpec.kt
@@ -73,7 +73,7 @@ class InAppMessageViewListenerOnClickSpec : InAppMessageViewListenerSpec() {
         When calling mockCheckbox.isChecked itReturns true
         listener.onClick(mockCheckbox)
 
-        Mockito.verify(mockCheckbox, Mockito.times(1)).isChecked
+        Mockito.verify(mockCheckbox).isChecked
     }
 
     @Test
@@ -397,6 +397,6 @@ class InAppMessageViewListenerOnKeySpec : InAppMessageViewListenerSpec() {
 
         listener.onKey(mockView, KeyEvent.KEYCODE_BACK, keyEvent).shouldBeTrue()
 
-        Mockito.verify(mockDisplayManager, Mockito.times(1)).removeMessage(any())
+        Mockito.verify(mockDisplayManager).removeMessage(any())
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ConfigSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ConfigSchedulerSpec.kt
@@ -43,6 +43,6 @@ class ConfigSchedulerSpec : BaseTest() {
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test", "",
                 isDebugLogging = false, isForTesting = true, configScheduler = mockConfigScheduler)
 
-        Mockito.verify(mockConfigScheduler, Mockito.times(1)).startConfig()
+        Mockito.verify(mockConfigScheduler).startConfig()
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationSchedulerSpec.kt
@@ -68,7 +68,7 @@ class EventMessageReconciliationSchedulerSpec : BaseTest() {
         LocalEventRepository.instance().clearEvents()
         EventsManager.onEventReceived(PurchaseSuccessfulEvent(), eventScheduler = mockSched, accountRepo = mockAccount)
 
-        Mockito.verify(mockSched, Mockito.times(1)).startEventMessageReconciliationWorker()
+        Mockito.verify(mockSched).startEventMessageReconciliationWorker()
     }
 
     companion object {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
@@ -9,18 +9,25 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.never
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
+import com.rakuten.tech.mobile.inappmessaging.runtime.InApp
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessagingTestConstants
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.AppStartEvent
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.PurchaseSuccessfulEvent
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.config.ConfigResponse
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.config.ConfigResponseData
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RetryDelayUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.ConfigScheduler
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.MessageMixerPingScheduler
 import org.amshove.kluent.*
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.*
@@ -33,95 +40,28 @@ import retrofit2.Response
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
-class ConfigWorkerSpec : BaseTest() {
+@Ignore("base class")
+open class ConfigWorkerSpec : BaseTest() {
 
     @Mock
-    private val mockResponse: Response<ConfigResponse?>? = null
-    private val context = Mockito.mock(Context::class.java)
-    private val workerParameters = Mockito.mock(WorkerParameters::class.java)
-    private val mockHostRespository = Mockito.mock(HostAppInfoRepository::class.java)
-    private val mockConfigRespository = Mockito.mock(ConfigResponseRepository::class.java)
-    private val mockMessageScheduler = Mockito.mock(MessageMixerPingScheduler::class.java)
-    private val mockRetry = Mockito.mock(RetryDelayUtil::class.java)
-    private val mockConfigScheduler = Mockito.mock(ConfigScheduler::class.java)
+    internal val mockResponse: Response<ConfigResponse?>? = null
+    internal val context = Mockito.mock(Context::class.java)
+    internal val workerParameters = Mockito.mock(WorkerParameters::class.java)
+    internal val mockHostRepository = Mockito.mock(HostAppInfoRepository::class.java)
+    internal val mockConfigRepository = Mockito.mock(ConfigResponseRepository::class.java)
+    internal val mockMessageScheduler = Mockito.mock(MessageMixerPingScheduler::class.java)
+    internal val mockRetry = Mockito.mock(RetryDelayUtil::class.java)
+    internal val mockConfigScheduler = Mockito.mock(ConfigScheduler::class.java)
 
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
         ConfigScheduler.currDelay = RetryDelayUtil.INITIAL_BACKOFF_DELAY
+        LocalEventRepository.instance().clearEvents()
+        ConfigResponseRepository.resetInstance()
     }
 
-    @Test
-    fun `should retry if server fail`() {
-        When calling mockResponse?.isSuccessful itReturns false
-        When calling mockResponse?.code() itReturns 500
-        When calling mockResponse?.body() itReturns null
-        ConfigWorker(context,
-                workerParameters).onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.retry()
-    }
-
-    @Test
-    fun `should fail if request fail`() {
-        When calling mockResponse?.isSuccessful itReturns false
-        When calling mockResponse?.code() itReturns 400
-        val worker = ConfigWorker(context, workerParameters)
-        worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.failure()
-    }
-
-    @Test
-    fun `should fail if hostapp id is null`() {
-        When calling mockHostRespository.getPackageName() itReturns null
-        val worker = ConfigWorker(context, workerParameters, mockHostRespository, ConfigResponseRepository.instance(),
-                MessageMixerPingScheduler.instance())
-        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
-    }
-
-    @Test
-    fun `should fail if hostapp id is empty`() {
-        When calling mockHostRespository.getPackageName() itReturns ""
-        val worker = ConfigWorker(context, workerParameters, mockHostRespository, ConfigResponseRepository.instance(),
-                MessageMixerPingScheduler.instance())
-        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
-    }
-
-    @Test
-    fun `should fail if hostapp version is null`() {
-        When calling mockHostRespository.getPackageName() itReturns "valid.package.name"
-        val worker = ConfigWorker(context, workerParameters, mockHostRespository, ConfigResponseRepository.instance(),
-                MessageMixerPingScheduler.instance())
-        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
-    }
-
-    @Test
-    fun `should fail if hostapp version is empty`() {
-        When calling mockHostRespository.getPackageName() itReturns "valid.package.name"
-        When calling mockHostRespository.getVersion() itReturns ""
-        val worker = ConfigWorker(context, workerParameters, mockHostRespository, ConfigResponseRepository.instance(),
-                MessageMixerPingScheduler.instance())
-        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
-    }
-
-    @Test
-    fun `should return success with valid values`() {
-        val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val app = ctx.packageManager.getApplicationInfo(ctx.packageName,
-                PackageManager.GET_META_DATA)
-        val bundle = app.metaData
-        When calling mockHostRespository.getPackageName() itReturns ctx.packageName
-        val version = ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName
-        When calling mockHostRespository.getVersion() itReturns version
-        When calling mockHostRespository.getConfigUrl() itReturns bundle.getString(CONFIG_KEY, "")
-        When calling mockHostRespository
-                .getInAppMessagingSubscriptionKey() itReturns bundle.getString(SUBSCRIPTION_KEY, "")
-        val worker = ConfigWorker(context, workerParameters, mockHostRespository, mockConfigRespository,
-                mockMessageScheduler)
-        val expected = if (HostAppInfoRepository.instance().getConfigUrl().isNullOrEmpty())
-            ListenableWorker.Result.retry() else ListenableWorker.Result.success()
-        worker.doWork() shouldBeEqualTo expected
-    }
-
-    @Test
-    fun `should return success with valid values not mock`() {
+    internal fun initializeInstance() {
         val testAppInfo = HostAppInfo("rakuten.com.tech.mobile.test",
                 InAppMessagingTestConstants.DEVICE_ID, InAppMessagingTestConstants.APP_VERSION,
                 "test-key", InAppMessagingTestConstants.LOCALE)
@@ -135,6 +75,47 @@ class ConfigWorkerSpec : BaseTest() {
 
         InAppMessaging.init(ApplicationProvider.getApplicationContext(), "test",
                 bundle.getString(CONFIG_KEY, ""), isDebugLogging = false, isForTesting = true)
+    }
+
+    internal fun setupMock(rollout: Int) {
+        val mockConfig = Mockito.mock(ConfigResponse::class.java)
+        val mockData = Mockito.mock(ConfigResponseData::class.java)
+        When calling mockResponse?.isSuccessful itReturns true
+        When calling mockResponse?.body() itReturns mockConfig
+        When calling mockConfig.data itReturns mockData
+        When calling mockData.rollOutPercentage itReturns rollout
+    }
+
+    companion object {
+        internal const val CONFIG_KEY = "com.rakuten.tech.mobile.inappmessaging.configurl"
+        internal const val SUBSCRIPTION_KEY = "com.rakuten.tech.mobile.inappmessaging.subscriptionkey"
+    }
+}
+
+class ConfigWorkerSuccessSpec : ConfigWorkerSpec() {
+    @Test
+    fun `should return success with valid values`() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val app = ctx.packageManager.getApplicationInfo(ctx.packageName,
+                PackageManager.GET_META_DATA)
+        val bundle = app.metaData
+        When calling mockHostRepository.getPackageName() itReturns ctx.packageName
+        val version = ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName
+        When calling mockHostRepository.getVersion() itReturns version
+        When calling mockHostRepository.getConfigUrl() itReturns bundle.getString(CONFIG_KEY, "")
+        When calling mockHostRepository
+                .getInAppMessagingSubscriptionKey() itReturns bundle.getString(SUBSCRIPTION_KEY, "")
+        val worker = ConfigWorker(context, workerParameters, mockHostRepository, mockConfigRepository,
+                mockMessageScheduler)
+        val expected = if (HostAppInfoRepository.instance().getConfigUrl().isNullOrEmpty())
+            ListenableWorker.Result.retry() else ListenableWorker.Result.success()
+        worker.doWork() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `should return success with valid values not mock`() {
+        initializeInstance()
+
         val worker = ConfigWorker(context, workerParameters)
         val expected = if (HostAppInfoRepository.instance().getConfigUrl().isNullOrEmpty())
             ListenableWorker.Result.retry() else ListenableWorker.Result.success()
@@ -172,8 +153,8 @@ class ConfigWorkerSpec : BaseTest() {
     fun `should reset initial delay`() {
         When calling mockResponse?.isSuccessful itReturns false
         When calling mockResponse?.code() itReturns RetryDelayUtil.RETRY_ERROR_CODE
-        val worker = ConfigWorker(context, workerParameters, mockHostRespository,
-                mockConfigRespository, mockMessageScheduler, mockConfigScheduler)
+        val worker = ConfigWorker(context, workerParameters, mockHostRepository,
+                mockConfigRepository, mockMessageScheduler, mockConfigScheduler)
         worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.Success()
         Mockito.verify(mockConfigScheduler).startConfig(eq(RetryDelayUtil.INITIAL_BACKOFF_DELAY))
 
@@ -184,8 +165,100 @@ class ConfigWorkerSpec : BaseTest() {
         ConfigScheduler.currDelay shouldBeEqualTo RetryDelayUtil.INITIAL_BACKOFF_DELAY
     }
 
-    companion object {
-        private const val CONFIG_KEY = "com.rakuten.tech.mobile.inappmessaging.configurl"
-        private const val SUBSCRIPTION_KEY = "com.rakuten.tech.mobile.inappmessaging.subscriptionkey"
+    @Test
+    fun `should log events when config is enabled`() {
+        setupMock(100)
+        initializeInstance()
+        InAppMessaging.instance().logEvent(AppStartEvent())
+        InAppMessaging.instance().logEvent(PurchaseSuccessfulEvent())
+        (InAppMessaging.instance() as InApp).tempEventList.shouldHaveSize(2)
+        LocalEventRepository.instance().getEvents().shouldBeEmpty()
+
+        val worker = ConfigWorker(context, workerParameters, HostAppInfoRepository.instance(),
+                ConfigResponseRepository.instance(), mockMessageScheduler, mockConfigScheduler)
+        worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.Success()
+        (InAppMessaging.instance() as InApp).tempEventList.shouldBeEmpty()
+        LocalEventRepository.instance().getEvents().shouldHaveSize(2)
+        Mockito.verify(mockMessageScheduler).pingMessageMixerService(0)
+    }
+
+    @Test
+    fun `should clear temp events when config is disabled`() {
+        setupMock(0)
+
+        initializeInstance()
+        InAppMessaging.instance().logEvent(AppStartEvent())
+        InAppMessaging.instance().logEvent(PurchaseSuccessfulEvent())
+        (InAppMessaging.instance() as InApp).tempEventList.shouldHaveSize(2)
+        LocalEventRepository.instance().getEvents().shouldBeEmpty()
+
+        val worker = ConfigWorker(context, workerParameters, HostAppInfoRepository.instance(),
+                ConfigResponseRepository.instance(), mockMessageScheduler, mockConfigScheduler)
+        worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.Success()
+        InAppMessaging.instance() shouldBeInstanceOf InAppMessaging.NotInitializedInAppMessaging::class.java
+        LocalEventRepository.instance().getEvents().shouldBeEmpty()
+        Mockito.verify(mockMessageScheduler, never()).pingMessageMixerService(0)
+    }
+}
+
+class ConfigWorkerFailSpec : ConfigWorkerSpec() {
+    @Test
+    fun `should retry if server fail`() {
+        initializeInstance()
+        InAppMessaging.instance() shouldBeInstanceOf InApp::class.java
+        When calling mockResponse?.isSuccessful itReturns false
+        When calling mockResponse?.code() itReturns 500
+        When calling mockResponse?.body() itReturns null
+        ConfigWorker(context,
+                workerParameters).onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.retry()
+
+        // should not reset instance
+        InAppMessaging.instance() shouldBeInstanceOf InApp::class.java
+    }
+
+    @Test
+    fun `should fail if request fail`() {
+        initializeInstance()
+        InAppMessaging.instance() shouldBeInstanceOf InApp::class.java
+        When calling mockResponse?.isSuccessful itReturns false
+        When calling mockResponse?.code() itReturns 400
+        val worker = ConfigWorker(context, workerParameters)
+        worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.failure()
+
+        // should reset instance
+        InAppMessaging.instance() shouldBeInstanceOf InAppMessaging.NotInitializedInAppMessaging::class.java
+    }
+
+    @Test
+    fun `should fail if hostapp id is null`() {
+        When calling mockHostRepository.getPackageName() itReturns null
+        val worker = ConfigWorker(context, workerParameters, mockHostRepository, ConfigResponseRepository.instance(),
+                MessageMixerPingScheduler.instance())
+        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
+    }
+
+    @Test
+    fun `should fail if hostapp id is empty`() {
+        When calling mockHostRepository.getPackageName() itReturns ""
+        val worker = ConfigWorker(context, workerParameters, mockHostRepository, ConfigResponseRepository.instance(),
+                MessageMixerPingScheduler.instance())
+        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
+    }
+
+    @Test
+    fun `should fail if hostapp version is null`() {
+        When calling mockHostRepository.getPackageName() itReturns "valid.package.name"
+        val worker = ConfigWorker(context, workerParameters, mockHostRepository, ConfigResponseRepository.instance(),
+                MessageMixerPingScheduler.instance())
+        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
+    }
+
+    @Test
+    fun `should fail if hostapp version is empty`() {
+        When calling mockHostRepository.getPackageName() itReturns "valid.package.name"
+        When calling mockHostRepository.getVersion() itReturns ""
+        val worker = ConfigWorker(context, workerParameters, mockHostRepository, ConfigResponseRepository.instance(),
+                MessageMixerPingScheduler.instance())
+        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
     }
 }


### PR DESCRIPTION
# Description
When config is disabled (possibly because of low rollout percentage), logging of events and displaying/removing of campaigns are also disabled.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors