### PR TITLE
fix: add user info update when moving temp data to persistent cache when config is enabled

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -114,6 +114,7 @@ internal class InApp(
             SharePreferencesUtil.generateKey(context), AccountRepository.instance().userInfoHash)
 
     override fun saveTempData() {
+        AccountRepository.instance().updateUserInfo()
         synchronized(tempEventList) {
             tempEventList.forEach { LocalEventRepository.instance().addEvent(it) }
             tempEventList.clear()


### PR DESCRIPTION
# Description
Because of timing issue (edge case), it is possible that the user info is not yet updated when moving temp events to persistent data.
Temp events were used for logged events while config API request is still in progress.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors