### PR TITLE
refactor: [SDKCF-4002] delete old events used to trigger new campaigns

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -35,6 +35,13 @@ internal interface LocalEventRepository : EventRepository {
      */
     fun clearNonPersistentEvents()
 
+    /**
+     * This method removes all stored non-persistent events triggered before the given time [timeMillis].
+     *
+     * @param timeMillis represents the given time in UTC milliseconds from the epoch.
+     */
+    fun clearNonPersistentEvents(timeMillis: Long)
+
     companion object {
         private const val TAG = "IAM_LocalEventRepo"
         private var instance: LocalEventRepository = LocalEventRepositoryImpl()
@@ -115,6 +122,17 @@ internal interface LocalEventRepository : EventRepository {
             synchronized(events) {
                 if (events.isNotEmpty()) {
                     events.removeAll { ev -> !ev.isPersistentType() }
+                }
+            }
+        }
+
+        /**
+         * {@inheritDoc}.
+         * */
+        override fun clearNonPersistentEvents(timeMillis: Long) {
+            synchronized(events) {
+                if (events.isNotEmpty()) {
+                    events.removeAll { ev -> !ev.isPersistentType() && ev.getTimestamp() < timeMillis }
                 }
             }
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Messa
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.requests.PingRequest
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.MessageMixerResponse
@@ -19,6 +20,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.Mes
 import retrofit2.Response
 import timber.log.Timber
 import java.net.HttpURLConnection
+import kotlin.collections.ArrayList
 
 /**
  * This class contains the actual work to communicate with Message Mixer Service. It extends Worker
@@ -97,6 +99,9 @@ internal class MessageMixerWorker(
 
                 // Add all parsed messages into PingResponseMessageRepository.
                 PingResponseMessageRepository.instance().replaceAllMessages(parsedMessages)
+
+                // Clear non-persistent local events triggered before current ping
+                LocalEventRepository.instance().clearNonPersistentEvents(messageMixerResponse.currentPingMillis)
 
                 // Start a new MessageEventReconciliationWorker, there was a new Ping Response to parse.
                 // This worker will attempt to cancel message scheduled but hasn't been displayed yet

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
 
 /**
  * Test class for LocalEventRepository.
@@ -121,6 +122,31 @@ open class LocalEventRepositorySpec : BaseTest() {
         LocalEventRepository.instance().addEvent(PurchaseSuccessfulEvent())
         LocalEventRepository.instance().addEvent(CustomEvent("test"))
         LocalEventRepository.instance().getEvents().shouldHaveSize(4)
+    }
+
+    @Test
+    fun `should remove all events triggered before a given time`() {
+        initializeLocalEvent()
+        LocalEventRepository.instance().getEvents().shouldHaveSize(4)
+        val timeMillis = LocalEventRepository.instance().getEvents()[3].getTimestamp() + 1
+        LocalEventRepository.instance().clearNonPersistentEvents(timeMillis)
+        LocalEventRepository.instance().getEvents().shouldHaveSize(1)
+    }
+
+    @Test
+    fun `should keep all events triggered after a given time`() {
+        initializeLocalEvent()
+        LocalEventRepository.instance().getEvents().shouldHaveSize(4)
+        val timeMillis = LocalEventRepository.instance().getEvents()[0].getTimestamp() - 1
+        LocalEventRepository.instance().clearNonPersistentEvents(timeMillis)
+        LocalEventRepository.instance().getEvents().shouldHaveSize(4)
+    }
+
+    @Test
+    fun `should not throw exception when clearing with empty events for a given time`() {
+        val timeMillis = Calendar.getInstance().timeInMillis
+        LocalEventRepository.instance().clearNonPersistentEvents(timeMillis)
+        LocalEventRepository.instance().getEvents().shouldHaveSize(0)
     }
 
     @Test


### PR DESCRIPTION
Fix issue where old triggered events in cache are still used for new campaigns.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
