### PR TITLE
fix: [SDKCF 4002] old events can still be used to trigger new campaigns

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -8,7 +8,6 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
@@ -85,8 +84,7 @@ internal class InApp(
     override fun unregisterMessageDisplayActivity() {
         try {
             if (ConfigResponseRepository.instance().isConfigEnabled()) {
-                val id = displayManager.removeMessage(getRegisteredActivity())
-                LocalDisplayedMessageRepository.instance().setRemovedMessage(id as String?)
+                displayManager.removeMessage(getRegisteredActivity())
             }
             activityWeakReference?.clear()
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull
 import androidx.annotation.Nullable
 import androidx.annotation.RestrictTo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDisplayedMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.Initializer
@@ -150,7 +149,6 @@ abstract class InAppMessaging internal constructor() {
 
             // inform repositories that it is initial launch to display app launch campaign at least once
             PingResponseMessageRepository.isInitialLaunch = true
-            LocalDisplayedMessageRepository.isInitialLaunch = true
 
             configScheduler.startConfig()
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutine.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutine.kt
@@ -67,7 +67,6 @@ internal class MessageActionsCoroutine(
 
         // Adding message to LocalDisplayedMessageRepository.
         localDisplayRepo.addMessage(message)
-        localDisplayRepo.setRemovedMessage("")
 
         // If message is opted out, add it to LocalOptedOutMessageRepository.
         if (optOut) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -28,11 +28,6 @@ internal interface LocalDisplayedMessageRepository {
     fun addMessage(message: Message)
 
     /**
-     * Sets the last message campaign ID in the repository which was closed after unregistering activity.
-     */
-    fun setRemovedMessage(id: String?)
-
-    /**
      * Return the number of times this message has been displayed in this session.
      * When message is null or message's campaignId is empty, return 0.
      */
@@ -111,12 +106,6 @@ internal interface LocalDisplayedMessageRepository {
                 }
                 saveUpdatedMap()
             }
-        }
-
-        override fun setRemovedMessage(id: String?) {
-            checkAndResetMap()
-            removedMessage = id ?: ""
-            saveUpdatedMap()
         }
 
         override fun numberOfTimesDisplayed(message: Message): Int {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -47,7 +47,7 @@ internal interface LocalDisplayedMessageRepository {
      * @return the number of times this message has been displayed,
      * when message is null or message's campaignId is empty, return 0.
      */
-    fun numberOfTimesDisplayedAfterLastPing(message: Message): Int
+    fun numberOfDisplaysAfterPing(message: Message): Int
 
     /**
      * Returns the number of times the campaign ID was closed after unregistering activity.
@@ -147,9 +147,9 @@ internal interface LocalDisplayedMessageRepository {
         }
 
         /**
-         * {@inheritDoc}
+         * {@inheritDoc}.
          */
-        override fun numberOfTimesDisplayedAfterLastPing(message: Message): Int {
+        override fun numberOfDisplaysAfterPing(message: Message): Int {
             synchronized(messages) {
                 val lastPingMillis = PingResponseMessageRepository.instance().lastPingMillis
                 val messageTimeStampList = messages[message.getCampaignId()]?.filter {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -50,11 +50,6 @@ internal interface LocalDisplayedMessageRepository {
     fun numberOfDisplaysAfterPing(message: Message): Int
 
     /**
-     * Returns the number of times the campaign ID was closed after unregistering activity.
-     */
-    fun numberOfTimesClosed(id: String): Int
-
-    /**
      * This method removes all stored messages.
      * This is done during session update due to user info update.
      */
@@ -122,20 +117,6 @@ internal interface LocalDisplayedMessageRepository {
             checkAndResetMap()
             removedMessage = id ?: ""
             saveUpdatedMap()
-        }
-
-        override fun numberOfTimesClosed(id: String): Int {
-            synchronized(removedMessages) {
-                if (isInitialLaunch && removedMessage.isNotEmpty()) {
-                    isInitialLaunch = false
-                    // only increment if campaign is removed then relaunch
-                    removedMessages[removedMessage] = removedMessages.getOrElse(removedMessage) { 0 } + 1
-                    saveUpdatedMap()
-                } else {
-                    checkAndResetMap()
-                }
-                return removedMessages[id] ?: 0
-            }
         }
 
         override fun numberOfTimesDisplayed(message: Message): Int {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -39,6 +39,17 @@ internal interface LocalDisplayedMessageRepository {
     fun numberOfTimesDisplayed(message: Message): Int
 
     /**
+     * Return the number of times this message has been displayed in this session
+     * after the last ping request response.
+     *
+     * @param message the given InApp campaign message.
+     *
+     * @return the number of times this message has been displayed,
+     * when message is null or message's campaignId is empty, return 0.
+     */
+    fun numberOfTimesDisplayedAfterLastPing(message: Message): Int
+
+    /**
      * Returns the number of times the campaign ID was closed after unregistering activity.
      */
     fun numberOfTimesClosed(id: String): Int
@@ -132,6 +143,19 @@ internal interface LocalDisplayedMessageRepository {
                 // Prevents race condition.
                 val messageTimeStampList = messages[message.getCampaignId()]
                 return messageTimeStampList?.size ?: 0
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        override fun numberOfTimesDisplayedAfterLastPing(message: Message): Int {
+            synchronized(messages) {
+                val lastPingMillis = PingResponseMessageRepository.instance().lastPingMillis
+                val messageTimeStampList = messages[message.getCampaignId()]?.filter {
+                    it > lastPingMillis
+                } ?: mutableListOf()
+                return messageTimeStampList.size
             }
         }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -75,6 +75,7 @@ internal interface LocalDisplayedMessageRepository {
         fun instance() = instance
     }
 
+    @SuppressWarnings("TooManyFunctions")
     private class LocalDisplayedMessageRepositoryImpl : LocalDisplayedMessageRepository {
         // Displayed message campaign ID and a list of the epoch time in UTC this message was displayed.
         // Such as:
@@ -153,7 +154,7 @@ internal interface LocalDisplayedMessageRepository {
             synchronized(messages) {
                 val lastPingMillis = PingResponseMessageRepository.instance().lastPingMillis
                 val messageTimeStampList = messages[message.getCampaignId()]?.filter {
-                    it > lastPingMillis
+                    it >= lastPingMillis
                 } ?: mutableListOf()
                 return messageTimeStampList.size
             }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
@@ -259,11 +259,12 @@ internal interface MessageEventReconciliationUtil {
         @SuppressWarnings("FunctionMaxLength")
         private fun getNumTimesToSatisfyTriggersForDisplay(message: Message): Int {
             val maxImpression = message.getMaxImpressions()
-            val displayedImpression: Int = LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message)
-            val displayedImpressionAfterLastPing: Int = LocalDisplayedMessageRepository.instance().numberOfTimesDisplayedAfterLastPing(message)
+            val displayedImpression: Int = LocalDisplayedMessageRepository.instance()
+                    .numberOfTimesDisplayed(message)
+            val displayedImpressionAfterLastPing: Int = LocalDisplayedMessageRepository.instance()
+                    .numberOfDisplaysAfterPing(message)
             val incrementRemoved = message.getCampaignId()?.let {
-                LocalDisplayedMessageRepository.instance()
-                        .numberOfTimesClosed(it)
+                LocalDisplayedMessageRepository.instance().numberOfTimesClosed(it)
             } ?: 0
 
             // Only check for message has been displayed less than its max impressions.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
@@ -263,15 +263,12 @@ internal interface MessageEventReconciliationUtil {
                     .numberOfTimesDisplayed(message)
             val displayedImpressionAfterLastPing: Int = LocalDisplayedMessageRepository.instance()
                     .numberOfDisplaysAfterPing(message)
-            val incrementRemoved = message.getCampaignId()?.let {
-                LocalDisplayedMessageRepository.instance().numberOfTimesClosed(it)
-            } ?: 0
 
             // Only check for message has been displayed less than its max impressions.
             // The number of times the message was removed from ready for display repository is considered since local
             // event list was not cleared and the triggers should  all be satisfied again.
             return if (maxImpression != null && displayedImpression < maxImpression) {
-                displayedImpressionAfterLastPing + 1 + message.getNumberOfTimesClosed() + incrementRemoved
+                displayedImpressionAfterLastPing + 1 + message.getNumberOfTimesClosed()
             } else 0
         }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtil.kt
@@ -260,6 +260,7 @@ internal interface MessageEventReconciliationUtil {
         private fun getNumTimesToSatisfyTriggersForDisplay(message: Message): Int {
             val maxImpression = message.getMaxImpressions()
             val displayedImpression: Int = LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message)
+            val displayedImpressionAfterLastPing: Int = LocalDisplayedMessageRepository.instance().numberOfTimesDisplayedAfterLastPing(message)
             val incrementRemoved = message.getCampaignId()?.let {
                 LocalDisplayedMessageRepository.instance()
                         .numberOfTimesClosed(it)
@@ -269,7 +270,7 @@ internal interface MessageEventReconciliationUtil {
             // The number of times the message was removed from ready for display repository is considered since local
             // event list was not cleared and the triggers should  all be satisfied again.
             return if (maxImpression != null && displayedImpression < maxImpression) {
-                displayedImpression + 1 + message.getNumberOfTimesClosed() + incrementRemoved
+                displayedImpressionAfterLastPing + 1 + message.getNumberOfTimesClosed() + incrementRemoved
             } else 0
         }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -109,52 +109,6 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
     }
 
     @Test
-    fun `should return zero for times closed when not first launch`() {
-        initializeInstance(TestUserInfoProvider())
-        LocalDisplayedMessageRepository.isInitialLaunch = false
-        LocalDisplayedMessageRepository.instance().setRemovedMessage("1234")
-
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("1234") shouldBeEqualTo 0
-    }
-
-    @Test
-    fun `should return correct number of times closed for removed when first launch`() {
-        initializeInstance(TestUserInfoProvider(), false)
-        LocalDisplayedMessageRepository.isInitialLaunch = true
-        LocalDisplayedMessageRepository.instance().setRemovedMessage("1234")
-
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("1234") shouldBeEqualTo 1
-        // should not increment since no longer initial launch
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("1234") shouldBeEqualTo 1
-
-        // should increment since initial launch
-        LocalDisplayedMessageRepository.isInitialLaunch = true
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("1234") shouldBeEqualTo 2
-    }
-
-    @Test
-    fun `should return false for removed when first launch and no removed messages`() {
-        initializeInstance(TestUserInfoProvider(), false)
-        LocalDisplayedMessageRepository.isInitialLaunch = true
-        LocalDisplayedMessageRepository.instance().setRemovedMessage("")
-
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("1234") shouldBeEqualTo 0
-
-        LocalDisplayedMessageRepository.instance().setRemovedMessage(null)
-
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("1234") shouldBeEqualTo 0
-    }
-
-    @Test
-    fun `should return false not the same campaign id`() {
-        initializeInstance(TestUserInfoProvider(), false)
-        LocalDisplayedMessageRepository.isInitialLaunch = true
-        LocalDisplayedMessageRepository.instance().setRemovedMessage("1234")
-
-        LocalDisplayedMessageRepository.instance().numberOfTimesClosed("4321") shouldBeEqualTo 0
-    }
-
-    @Test
     fun `should not crash and clear previous when forced cast exception`() {
         val message = setupAndTestMultipleUser()
         val editor = InAppMessaging.instance().getSharedPref()?.edit()

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -112,9 +112,7 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
     fun `should not crash and clear previous when forced cast exception`() {
         val message = setupAndTestMultipleUser()
         val editor = InAppMessaging.instance().getSharedPref()?.edit()
-        editor?.putInt(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_CLOSED_LIST_KEY, 1)
-                ?.putInt(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_CLOSED_KEY, 1)
-                ?.putInt(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_KEY, 1)?.apply()
+        editor?.putInt(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_KEY, 1)?.apply()
 
         LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
     }
@@ -123,9 +121,7 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
     fun `should not crash and clear previous when invalid format`() {
         val message = setupAndTestMultipleUser()
         val editor = InAppMessaging.instance().getSharedPref()?.edit()
-        editor?.putString(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_CLOSED_LIST_KEY, "invalid")
-                ?.putString(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_CLOSED_KEY, "invalid")
-                ?.putString(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_KEY, "invalid")?.apply()
+        editor?.putString(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_KEY, "invalid")?.apply()
 
         LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -16,10 +16,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
+import java.util.*
 
 /**
  * Test class for LocalDisplayedMessageRepository.
  */
+@SuppressWarnings("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class LocalDisplayedMessageRepositorySpec : BaseTest() {
 
@@ -172,6 +174,24 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
                 ?.putString(LocalDisplayedMessageRepository.LOCAL_DISPLAYED_KEY, "invalid")?.apply()
 
         LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
+    }
+
+    @Test
+    @Synchronized
+    fun `should return valid timestamp list after last ping`() {
+        val message = ValidTestMessage()
+        PingResponseMessageRepository.instance().lastPingMillis = Calendar.getInstance().timeInMillis
+        LocalDisplayedMessageRepository.instance().addMessage(message)
+        LocalDisplayedMessageRepository.instance().numberOfDisplaysAfterPing(message) shouldBeEqualTo 1
+    }
+
+    @Test
+    @Synchronized
+    fun `should return empty timestamp list after last ping`() {
+        val message = ValidTestMessage()
+        LocalDisplayedMessageRepository.instance().addMessage(message)
+        PingResponseMessageRepository.instance().lastPingMillis = Calendar.getInstance().timeInMillis + 60000
+        LocalDisplayedMessageRepository.instance().numberOfDisplaysAfterPing(message) shouldBeEqualTo 0
     }
 
     private fun setupAndTestMultipleUser(): ValidTestMessage {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepositorySpec.kt
@@ -190,8 +190,19 @@ class LocalDisplayedMessageRepositorySpec : BaseTest() {
     fun `should return empty timestamp list after last ping`() {
         val message = ValidTestMessage()
         LocalDisplayedMessageRepository.instance().addMessage(message)
-        PingResponseMessageRepository.instance().lastPingMillis = Calendar.getInstance().timeInMillis + 60000
+        PingResponseMessageRepository.instance().lastPingMillis = Calendar.getInstance().timeInMillis + 5
         LocalDisplayedMessageRepository.instance().numberOfDisplaysAfterPing(message) shouldBeEqualTo 0
+    }
+
+    @Test
+    @Synchronized
+    fun `should return valid timestamp list when ping response time is between adding two messages`() {
+        val message = ValidTestMessage()
+        LocalDisplayedMessageRepository.instance().addMessage(message)
+        Thread.sleep(1)
+        PingResponseMessageRepository.instance().lastPingMillis = Calendar.getInstance().timeInMillis
+        LocalDisplayedMessageRepository.instance().addMessage(message)
+        LocalDisplayedMessageRepository.instance().numberOfDisplaysAfterPing(message) shouldBeEqualTo 1
     }
 
     private fun setupAndTestMultipleUser(): ValidTestMessage {

--- a/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
+++ b/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
@@ -34,6 +34,7 @@ class MainActivityFragment : Fragment(), View.OnClickListener {
         login_successful_twice.setOnClickListener(this)
         purchase_successful_twice.setOnClickListener(this)
         login_purchase_successful.setOnClickListener(this)
+        close_message.setOnClickListener(this)
     }
 
     override fun onClick(v: View) {
@@ -56,6 +57,9 @@ class MainActivityFragment : Fragment(), View.OnClickListener {
             login_purchase_successful -> {
                 InAppMessaging.instance().logEvent(LoginSuccessfulEvent())
                 InAppMessaging.instance().logEvent(PurchaseSuccessfulEvent().currencyCode("JPY"))
+            }
+            close_message -> {
+                InAppMessaging.instance().closeMessage()
             }
             else -> {
             }

--- a/test/src/main/res/layout/fragment_main.xml
+++ b/test/src/main/res/layout/fragment_main.xml
@@ -10,6 +10,12 @@
   tools:showIn="@layout/activity_main">
 
   <Button
+      android:id="@+id/close_message"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/close_message"/>
+
+  <Button
     android:id="@+id/launch_second_activity"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"

--- a/test/src/main/res/values/strings.xml
+++ b/test/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
   <string name="label_raetoken">RAE Token</string>
   <string name="label_rakutenid">Rakuten ID</string>
   <string name="dialog_title_user">User Information</string>
+  <string name="close_message">Close message</string>
 </resources>


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
