### PR TITLE
fix: add flag to event when user info was updated (session update) to avoid getting cleared

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/BaseEvent.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/BaseEvent.kt
@@ -29,6 +29,7 @@ abstract class BaseEvent(
     @NotNull private val isPersistent: Boolean
 ) : Event {
     private val timestamp: Long
+    private var isUserUpdated = false
 
     init {
         require(this.eventName.isNotEmpty()) { InAppMessagingConstants.EVENT_NAME_EMPTY_EXCEPTION }
@@ -85,6 +86,12 @@ abstract class BaseEvent(
     @RestrictTo(LIBRARY)
     @NotNull
     override fun getAttributeMap(): Map<@NotNull String, @Nullable Attribute?> = HashMap()
+
+    override fun isUserUpdated() = isUserUpdated
+
+    override fun setUserUpdated(isUpdated: Boolean) {
+        isUserUpdated = isUpdated
+    }
 
     companion object {
         private const val MAX_EVENT_NAME_CHARACTER_LENGTH = 255

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/Event.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/Event.kt
@@ -50,4 +50,14 @@ interface Event {
     @RestrictTo(LIBRARY)
     @NotNull
     fun getAttributeMap(): Map<@NotNull String, @Nullable Attribute?>
+
+    /**
+     * This method returns true if the event was logged when user information was updated.
+     */
+    fun isUserUpdated(): Boolean
+
+    /**
+     * Set to true if the event was logged when user information was updated.
+     */
+    fun setUserUpdated(isUpdated: Boolean)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalDisplayedMessageRepository.kt
@@ -140,6 +140,7 @@ internal interface LocalDisplayedMessageRepository {
             }
         }
 
+        @SuppressWarnings("TooGenericExceptionCaught")
         private fun resetDisplayed(sharedPref: SharedPreferences?) {
             val listString = try {
                 sharedPref?.getString(LOCAL_DISPLAYED_KEY, "") ?: ""

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -132,8 +132,16 @@ internal interface LocalEventRepository : EventRepository {
         override fun clearNonPersistentEvents(timeMillis: Long) {
             synchronized(events) {
                 if (events.isNotEmpty()) {
-                    events.removeAll { ev -> !ev.isPersistentType() && ev.getTimestamp() < timeMillis }
+                    events.removeAll { ev ->
+                        !ev.isPersistentType() && ev.getTimestamp() < timeMillis && !ev.isUserUpdated()
+                    }
+
+                    // reset user updated flag
+                    events.forEach {
+                        it.setUserUpdated(false)
+                    }
                 }
+                saveUpdatedList()
             }
         }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
@@ -30,6 +30,7 @@ internal object EventsManager {
     ) {
         val isUserUpdated = accountRepo.updateUserInfo()
         // Caching events locally.
+        event.setUserUpdated(isUserUpdated || isUpdated)
         val isAdded = localEventRepo.addEvent(event)
         if (isAdded) {
             if (isUserUpdated || isUpdated) {


### PR DESCRIPTION
# Description
Since old events are cleared after ping request, logged events that trigger session update will be cleared.
To avoid this, a flag is added for events which will prevent the event to be cleared

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
