### PR TITLE
fix: add gravity center for headers

### DIFF
--- a/inappmessaging/src/main/res/layout/message_scrollview.xml
+++ b/inappmessaging/src/main/res/layout/message_scrollview.xml
@@ -29,6 +29,7 @@
       android:lineSpacingExtra="@dimen/modal_text_header_line_spacing_extra"
       android:textSize="@dimen/modal_text_header_text_size"
       android:textAlignment="center"
+      android:gravity="center"
       tools:text="@string/example_header_text"
       tools:visibility="visible"/>
 


### PR DESCRIPTION
# Description
`textAlignment` alone is not working when `materials` dependency is included in app

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
