### PR TITLE
bug: add flag to handle log event timing issue during ping request

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Even
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
@@ -157,7 +158,10 @@ internal class InApp(
         try {
             AccountRepository.instance().updateUserInfo()
             synchronized(tempEventList) {
-                tempEventList.forEach { LocalEventRepository.instance().addEvent(it) }
+                tempEventList.forEach {
+                    it.setShouldNotClear(PingResponseMessageRepository.isInitialLaunch)
+                    LocalEventRepository.instance().addEvent(it)
+                }
                 tempEventList.clear()
             }
         } catch (ex: Exception) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/BaseEvent.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/BaseEvent.kt
@@ -29,7 +29,7 @@ abstract class BaseEvent(
     @NotNull private val isPersistent: Boolean
 ) : Event {
     private val timestamp: Long
-    private var isUserUpdated = false
+    private var shouldNotClear = false
 
     init {
         require(this.eventName.isNotEmpty()) { InAppMessagingConstants.EVENT_NAME_EMPTY_EXCEPTION }
@@ -87,10 +87,10 @@ abstract class BaseEvent(
     @NotNull
     override fun getAttributeMap(): Map<@NotNull String, @Nullable Attribute?> = HashMap()
 
-    override fun isUserUpdated() = isUserUpdated
+    override fun shouldNotClear() = shouldNotClear
 
-    override fun setUserUpdated(isUpdated: Boolean) {
-        isUserUpdated = isUpdated
+    override fun setShouldNotClear(shouldNotClear: Boolean) {
+        this.shouldNotClear = shouldNotClear
     }
 
     companion object {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/Event.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/Event.kt
@@ -52,12 +52,12 @@ interface Event {
     fun getAttributeMap(): Map<@NotNull String, @Nullable Attribute?>
 
     /**
-     * This method returns true if the event was logged when user information was updated.
+     * This method returns true if the event was logged when user info was updated, or before/during ping request.
      */
-    fun isUserUpdated(): Boolean
+    fun shouldNotClear(): Boolean
 
     /**
-     * Set to true if the event was logged when user information was updated.
+     * Set to true if the event was logged when user information was updated, or before/during ping request..
      */
-    fun setUserUpdated(isUpdated: Boolean)
+    fun setShouldNotClear(shouldNotClear: Boolean)
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepository.kt
@@ -133,12 +133,12 @@ internal interface LocalEventRepository : EventRepository {
             synchronized(events) {
                 if (events.isNotEmpty()) {
                     events.removeAll { ev ->
-                        !ev.isPersistentType() && ev.getTimestamp() < timeMillis && !ev.isUserUpdated()
+                        !ev.isPersistentType() && ev.getTimestamp() < timeMillis && !ev.shouldNotClear()
                     }
 
-                    // reset user updated flag
+                    // reset should not clear flag
                     events.forEach {
-                        it.setUserUpdated(false)
+                        it.setShouldNotClear(false)
                     }
                 }
                 saveUpdatedList()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/EventsManager.kt
@@ -6,6 +6,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Even
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalEventRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.PingResponseMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.EventMessageReconciliationScheduler
 
@@ -30,7 +31,7 @@ internal object EventsManager {
     ) {
         val isUserUpdated = accountRepo.updateUserInfo()
         // Caching events locally.
-        event.setUserUpdated(isUserUpdated || isUpdated)
+        event.setShouldNotClear(isUserUpdated || isUpdated || PingResponseMessageRepository.isInitialLaunch)
         val isAdded = localEventRepo.addEvent(event)
         if (isAdded) {
             if (isUserUpdated || isUpdated) {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/LocalEventRepositorySpec.kt
@@ -182,7 +182,7 @@ open class LocalEventRepositorySpec : BaseTest() {
     fun `should remove all events triggered before a given time with false user updated flag`() {
         initializeLocalEvent()
         val event = LoginSuccessfulEvent()
-        event.setUserUpdated(true)
+        event.setShouldNotClear(true)
         val timeMillis = event.getTimestamp() + 1
         LocalEventRepository.instance().addEvent(event)
         LocalEventRepository.instance().getEvents().shouldHaveSize(5)
@@ -193,7 +193,7 @@ open class LocalEventRepositorySpec : BaseTest() {
     @Test
     fun `should keep all events triggered after a given time with true user updated flag`() {
         val event = LoginSuccessfulEvent()
-        event.setUserUpdated(true)
+        event.setShouldNotClear(true)
         val timeMillis = event.getTimestamp() - 1
         LocalEventRepository.instance().addEvent(event)
         LocalEventRepository.instance().addEvent(event)
@@ -283,6 +283,6 @@ internal class TestEvent(private val name: String?) : Event {
     override fun isPersistentType(): Boolean = false
     override fun getRatEventMap(): Map<String, Any> = mapOf()
     override fun getAttributeMap(): Map<String, Attribute?> = mapOf()
-    override fun isUserUpdated() = false
-    override fun setUserUpdated(isUpdated: Boolean) {}
+    override fun shouldNotClear() = false
+    override fun setShouldNotClear(shouldNotClear: Boolean) {}
 }


### PR DESCRIPTION
# Description
added flag to handle logging of events while ping request is still in progress
* avoid clearing "old" events which were triggered while config request or ping request is ongoing

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
