### PR TITLE
improvement: add delay between campaign display

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/DisplaySettings.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/DisplaySettings.kt
@@ -19,5 +19,8 @@ internal data class DisplaySettings(
     val textAlign: Int,
 
     @SerializedName("optOut")
-    val optOut: Boolean
+    val optOut: Boolean,
+
+    @SerializedName("delay")
+    val delay: Int
 )

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
@@ -90,13 +90,17 @@ internal class InAppMessageViewListener(
         CoroutineScope(Dispatchers.Main).launch {
             displayManager.removeMessage(inApp.getRegisteredActivity())
             withContext(Dispatchers.Default) {
-                val result = messageCoroutine.executeTask(message, id, isOptOutChecked)
-                if (result) {
-                    eventScheduler.startEventMessageReconciliationWorker(
-                        delay = (message?.getMessagePayload()?.messageSettings?.displaySettings?.delay ?: 0).toLong()
-                    )
-                }
+                handleMessage(id)
             }
+        }
+    }
+
+    internal fun handleMessage(id: Int) {
+        val result = messageCoroutine.executeTask(message, id, isOptOutChecked)
+        if (result) {
+            eventScheduler.startEventMessageReconciliationWorker(
+                delay = (message?.getMessagePayload()?.messageSettings?.displaySettings?.delay ?: 0).toLong()
+            )
         }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
@@ -92,7 +92,9 @@ internal class InAppMessageViewListener(
             withContext(Dispatchers.Default) {
                 val result = messageCoroutine.executeTask(message, id, isOptOutChecked)
                 if (result) {
-                    eventScheduler.startEventMessageReconciliationWorker()
+                    eventScheduler.startEventMessageReconciliationWorker(
+                        delay = (message?.getMessagePayload()?.messageSettings?.displaySettings?.delay ?: 0).toLong()
+                    )
                 }
             }
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationScheduler.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationScheduler.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.InApp
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers.MessageEventReconciliationWorker
+import java.util.concurrent.TimeUnit
 
 /**
  * Scheduler for MessageEventReconciliationWorker. Providing static helper functions.
@@ -17,7 +18,7 @@ internal interface EventMessageReconciliationScheduler {
      * completed, schedule to display next ready message.
      */
     @SuppressWarnings("FunctionMaxLength")
-    fun startEventMessageReconciliationWorker(workManager: WorkManager? = null)
+    fun startEventMessageReconciliationWorker(workManager: WorkManager? = null, delay: Long = 0)
 
     companion object {
         private const val MESSAGES_EVENTS_WORKER_NAME = "iam_messages_events_worker"
@@ -28,12 +29,13 @@ internal interface EventMessageReconciliationScheduler {
 
     private class EventMessageReconciliationSchedulerImpl : EventMessageReconciliationScheduler {
 
-        @SuppressWarnings("FunctionMaxLength")
-        override fun startEventMessageReconciliationWorker(workManager: WorkManager?) {
+        @SuppressWarnings("FunctionMaxLength", "LongMethod")
+        override fun startEventMessageReconciliationWorker(workManager: WorkManager?, delay: Long) {
             // Starts MessageEventReconciliationWorker as a unique worker.
             // This worker must be a unique worker, but it can be replaced with a new one. Because we don't
             // want the same worker working in parallel which will result bad data, and unwanted behaviour.
             val reconciliationWorkRequest = OneTimeWorkRequest.Builder(MessageEventReconciliationWorker::class.java)
+                    .setInitialDelay(delay, TimeUnit.MILLISECONDS)
                     .addTag(MESSAGES_EVENTS_WORKER_NAME)
                     .build()
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
@@ -186,7 +186,8 @@ class MessageMixerResponseSpec(private val testname: String, private val actual:
                 messagePayload.messageSettings?.controlSettings)
         private val displaySettings = DisplaySettings(messageSettings.displaySettings?.orientation!!,
                 messageSettings.displaySettings.slideFrom, messageSettings.displaySettings.endTimeMillis,
-                messageSettings.displaySettings.textAlign, messageSettings.displaySettings.optOut)
+                messageSettings.displaySettings.textAlign, messageSettings.displaySettings.optOut,
+                messageSettings.displaySettings.delay)
         private val controlSettings = ControlSettings(messageSettings.controlSettings?.buttons,
                 messageSettings.controlSettings?.content!!)
         private val messageButton = MessageButton(controlSettings.buttons?.get(0)?.buttonBackgroundColor!!,


### PR DESCRIPTION
# Description
Add delay before displaying next campaign (sync with iOS)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
