### PR TITLE
fix: add display of next campaign when queue is not cleared

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -179,6 +179,7 @@ internal class InApp(
             ReadyForDisplayMessageRepository.instance().clearMessages(true)
         } else if (id != null) {
             ReadyForDisplayMessageRepository.instance().removeMessage(id as String, true)
+            displayManager.displayMessage()
         }
     }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -204,6 +204,26 @@ open class InAppMessagingSpec : BaseTest() {
     }
 
     @Test
+    fun `should call display manager when removing campaign but not clear queue`() {
+        val message = ValidTestMessage("1")
+        setupDisplayedView(message)
+        val instance = initializeMockInstance(100)
+
+        When calling displayManager.removeMessage(anyOrNull()) itReturns "1"
+        (instance as InApp).removeMessage(false)
+        ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
+        for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
+            if (msg.getCampaignId() == "1") {
+                msg.getNumberOfTimesClosed() shouldBeEqualTo 1
+            } else {
+                msg.getNumberOfTimesClosed() shouldBeEqualTo 0
+            }
+        }
+        LocalDisplayedMessageRepository.instance().numberOfTimesDisplayed(message) shouldBeEqualTo 0
+        Mockito.verify(displayManager).displayMessage()
+    }
+
+    @Test
     fun `should not increment when no message is displayed`() {
         val message = ValidTestMessage("1")
         ReadyForDisplayMessageRepository.instance().replaceAllMessages(listOf(message))

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -37,7 +37,7 @@ import kotlin.test.fail
 open class InAppMessagingSpec : BaseTest() {
     private val activity = Mockito.mock(Activity::class.java)
     private val configResponseData = Mockito.mock(ConfigResponseData::class.java)
-    internal val displayManager = Mockito.mock(DisplayManager::class.java)
+    private val displayManager = Mockito.mock(DisplayManager::class.java)
     internal val eventsManager = Mockito.mock(EventsManager::class.java)
     internal val sessionManager = Mockito.mock(SessionManager::class.java)
     private val viewGroup = Mockito.mock(ViewGroup::class.java)
@@ -210,6 +210,7 @@ open class InAppMessagingSpec : BaseTest() {
         val instance = initializeMockInstance(100)
 
         When calling displayManager.removeMessage(anyOrNull()) itReturns "1"
+
         (instance as InApp).removeMessage(false)
         ReadyForDisplayMessageRepository.instance().getAllMessagesCopy().shouldHaveSize(1)
         for (msg in PingResponseMessageRepository.instance().getAllMessagesCopy()) {
@@ -390,11 +391,11 @@ open class InAppMessagingSpec : BaseTest() {
         InAppMessaging.initialize(ApplicationProvider.getApplicationContext(), true, shouldEnableCaching)
     }
 
-    internal fun initializeMockInstance(rollout: Int): InAppMessaging {
+    internal fun initializeMockInstance(rollout: Int, manager: DisplayManager = displayManager): InAppMessaging {
         When calling configResponseData.rollOutPercentage itReturns rollout
         ConfigResponseRepository.instance().addConfigResponse(configResponseData)
 
-        return InApp(ApplicationProvider.getApplicationContext(), false, displayManager,
+        return InApp(ApplicationProvider.getApplicationContext(), false, manager,
                 eventsManager = eventsManager, sessionManager = sessionManager)
     }
 }
@@ -402,14 +403,15 @@ open class InAppMessagingSpec : BaseTest() {
 class InAppMessagingExceptionSpec : InAppMessagingSpec() {
 
     private val mockActivity = Mockito.mock(Activity::class.java)
-    private val instance = initializeMockInstance(100)
+    private val dispMgr = Mockito.mock(DisplayManager::class.java)
+    private val instance = initializeMockInstance(100, dispMgr)
 
     @Before
     override fun setup() {
         super.setup()
         InApp.errorCallback = null
-        When calling displayManager.displayMessage() itThrows NullPointerException()
-        When calling displayManager.removeMessage(anyOrNull()) itThrows NullPointerException()
+        When calling dispMgr.displayMessage() itThrows NullPointerException()
+        When calling dispMgr.removeMessage(anyOrNull()) itThrows NullPointerException()
         When calling eventsManager.onEventReceived(any(), any(), any(), any(), any()) itThrows NullPointerException()
         When calling sessionManager.onSessionUpdate() itThrows NullPointerException()
     }


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
