### PR TITLE
feat: update compile and target SDK to API 31 (Android 12)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     apply from: 'config/index.gradle'
 
     CONFIG.versions.android.sdk.min = 23
-    CONFIG.versions.android.sdk.target = 30
-    CONFIG.versions.android.sdk.compile = 30
+    CONFIG.versions.android.sdk.target = 31
+    CONFIG.versions.android.sdk.compile = 31
     CONFIG.versions.kotlin = '1.4.31'
 
     repositories {

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -5,7 +5,6 @@ apply from: '../config/quality/errorprone/android.gradle'
 apply from: '../config/documentation/dokka/android.gradle'
 
 apply plugin: "kotlin-android"
-apply plugin: 'kotlin-kapt'
 
 android {
   defaultConfig {
@@ -50,7 +49,7 @@ android {
 
 dependencies {
   // For Kotlin
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$CONFIG.versions.kotlin"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$CONFIG.versions.kotlin"
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 
@@ -64,8 +63,6 @@ dependencies {
   implementation 'com.squareup.retrofit2:retrofit:2.8.1'
   implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
   implementation 'com.google.code.gson:gson:2.8.6'
-  kapt "io.github.rakutentech.manifestconfig:manifest-config-processor:0.2.0"
-  implementation "io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0"
 
   // Doclava needs an annotation class from this package (used by Retrofit)
   compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.18'

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.inappmessaging.runtime
 
 import android.app.Activity
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.annotation.NonNull
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
@@ -16,8 +17,6 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.EventsManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.SessionManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.SharedPreferencesUtil
-import com.rakuten.tech.mobile.manifestconfig.annotations.ManifestConfig
-import com.rakuten.tech.mobile.manifestconfig.annotations.MetaData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -181,26 +180,25 @@ internal class InApp(
         }
     }
 
-    @ManifestConfig
-    internal interface App {
+    internal class AppManifestConfig(val context: Context) {
+
+        private val metadata = context.packageManager
+            .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA).metaData
 
         /**
          * Subscription Key from the InAppMessaging Dashboard.
          **/
-        @MetaData(key = "com.rakuten.tech.mobile.inappmessaging.subscriptionkey")
-        fun subscriptionKey(): String?
+        fun subscriptionKey(): String? = metadata.getString("com.rakuten.tech.mobile.inappmessaging.subscriptionkey")
 
         /**
          * Config URL for the IAM API.
          **/
-        @MetaData(key = "com.rakuten.tech.mobile.inappmessaging.configurl")
-        fun configUrl(): String?
+        fun configUrl(): String? = metadata.getString("com.rakuten.tech.mobile.inappmessaging.configurl")
 
         /**
          * Flag to enable/disable debug logging.
          **/
-        @MetaData(key = "com.rakuten.tech.mobile.inappmessaging.debugging", value = "false")
-        fun isDebugging(): Boolean
+        fun isDebugging(): Boolean = metadata.getBoolean("com.rakuten.tech.mobile.inappmessaging.debugging")
     }
 
     companion object {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -140,7 +140,7 @@ abstract class InAppMessaging internal constructor() {
             isCacheHandling: Boolean = false,
             configScheduler: ConfigScheduler = ConfigScheduler.instance()
         ) {
-            val manifestConfig = AppManifestConfig(context)
+            val manifestConfig = InApp.AppManifestConfig(context)
 
             // `manifestConfig.isDebugging()` is used to enable/disable the debug logging of InAppMessaging SDK.
             // Note: All InAppMessaging SDK logs' tags begins with "IAM_".

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
@@ -101,7 +101,7 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
         } else if (buttons?.size == 2) {
             // Set bigger layout_margin if there's only one button.
             findViewById<MaterialButton>(R.id.message_button_left)?.let { setButtonInfo(it, this.buttons!![0]) }
-            findViewById<MaterialButton>(R.id.message_button_right)?.let{ setButtonInfo(it, this.buttons!![1]) }
+            findViewById<MaterialButton>(R.id.message_button_right)?.let { setButtonInfo(it, this.buttons!![1]) }
         }
     }
 
@@ -181,7 +181,7 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
             findViewById<NestedScrollView>(R.id.message_scrollview)?.visibility = View.VISIBLE
         }
         if (!header.isNullOrEmpty()) {
-            findViewById<TextView>(R.id.header_text)?.let{
+            findViewById<TextView>(R.id.header_text)?.let {
                 it.text = header
                 it.setTextColor(headerColor)
                 it.setOnTouchListener(listener)
@@ -189,7 +189,7 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
             }
         }
         if (!messageBody.isNullOrEmpty()) {
-            findViewById<TextView>(R.id.message_body)?.let{
+            findViewById<TextView>(R.id.message_body)?.let {
                 it.text = messageBody
                 it.setTextColor(messageBodyColor)
                 it.setOnTouchListener(listener)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
@@ -6,7 +6,7 @@ import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
-import com.rakuten.tech.mobile.inappmessaging.runtime.AppManifestConfig
+import com.rakuten.tech.mobile.inappmessaging.runtime.InApp.AppManifestConfig
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -10,7 +10,7 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.never
-import com.rakuten.tech.mobile.inappmessaging.runtime.AppManifestConfig
+import com.rakuten.tech.mobile.inappmessaging.runtime.InApp.AppManifestConfig
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -4,7 +4,7 @@ apply plugin: "kotlin-android"
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "rakuten.com.tech.mobile.test"
@@ -13,7 +13,7 @@ android {
         // Defines the minimum API level required to run the app.
         minSdkVersion CONFIG.versions.android.sdk.min
         // Specifies the API level used to test the app.
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
# Description
Removed usage of manifest config because of `kapt` issue when using Android 12.
Changed to manual metadata retrieval

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
