### PR TITLE
feat: [SDKCF-4468] remove deprecated updateSession API

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -359,6 +359,7 @@ Documents targeting Product Managers:
   - Renamed method for providing access token in `UserInfoProvider` interface class from `provideRaeToken` to `provideAccessToken`.
   - Removed `provideRakutenId` method for Rakuten Id in `UserInfoProvider` interface class. Please use `provideUserId` for specific user targeting.
   - All the methods in `UserInfoProvider` class are optional for Kotlin class implementing the interface.
+* SDKCF-4468: **Breaking Change:** Removed deprecated updateSession() API.
 * SDKCF-4530: Fixed handling for case-sensitivity update for custom event and attribute name
 * SDKCF-4196: Updated dependencies due to JCenter shutdown.
 * SDKCF-4190: Updated Kluent dependency version due to deprecated mocking feature.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -111,19 +111,6 @@ internal class InApp(
         }
     }
 
-    override fun updateSession() {
-        try {
-            if (ConfigResponseRepository.instance().isConfigEnabled()) {
-                // Updates the current session to update all locally stored messages
-                sessionManager.onSessionUpdate()
-            }
-        } catch (ex: Exception) {
-            errorCallback?.let {
-                it(InAppMessagingException("In-App Messaging session update failed", ex))
-            }
-        }
-    }
-
     override fun closeMessage(clearQueuedCampaigns: Boolean) {
         try {
             if (ConfigResponseRepository.instance().isConfigEnabled()) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -52,14 +52,6 @@ abstract class InAppMessaging internal constructor() {
     abstract fun logEvent(@NonNull event: Event)
 
     /**
-     * This methods updates the host app's session. This allows InAppMessaging to update the locally stored
-     * messages which can be dependent on user information.
-     */
-    @Deprecated("This method is no longer needs to be called when updating user info because session updates" +
-            "are handled internally by the sdk.")
-    abstract fun updateSession()
-
-    /**
      * This method returns registered activity of the host app.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -172,8 +164,6 @@ abstract class InAppMessaging internal constructor() {
         override fun unregisterMessageDisplayActivity() {}
 
         override fun logEvent(event: Event) {}
-
-        override fun updateSession() {}
 
         override fun getRegisteredActivity(): Activity? = null
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -108,14 +108,6 @@ open class InAppMessagingSpec : BaseTest() {
     }
 
     @Test
-    // For code coverage. will be deleted when updateSession() is removed
-    fun `should not crash update session when using uninitialized instance`() {
-        InAppMessaging.setUninitializedInstance()
-        InAppMessaging.instance().registerPreference(TestUserInfoProvider())
-        InAppMessaging.instance().updateSession()
-    }
-
-    @Test
     fun `should display message using initialized instance`() {
         val inApp = initializeMockInstance(100)
         inApp.registerMessageDisplayActivity(activity)
@@ -139,19 +131,6 @@ open class InAppMessagingSpec : BaseTest() {
 
         try {
             InAppMessaging.instance().logEvent(AppStartEvent())
-        } catch (e: Exception) {
-            Assert.fail(EXCEPTION_MSG)
-        }
-    }
-
-    @Test
-    @SuppressWarnings("SwallowedException")
-    // For code coverage. will be deleted when updateSession() is removed
-    fun `should not crash update session for initialized instance`() {
-        initializeInstance()
-
-        try {
-            InAppMessaging.instance().updateSession()
         } catch (e: Exception) {
             Assert.fail(EXCEPTION_MSG)
         }
@@ -487,20 +466,6 @@ class InAppMessagingExceptionSpec : InAppMessagingSpec() {
     fun `should trigger callback when log event failed due to forced exception`() {
         InApp.errorCallback = mockCallback
         instance.logEvent(AppStartEvent())
-
-        Mockito.verify(mockCallback).invoke(captor.capture())
-        captor.firstValue shouldBeInstanceOf InAppMessagingException::class.java
-    }
-
-    @Test
-    fun `should not crash when update session failed due to forced exception`() {
-        instance.updateSession()
-    }
-
-    @Test
-    fun `should trigger callback when update session failed due to forced exception`() {
-        InApp.errorCallback = mockCallback
-        instance.updateSession()
 
         Mockito.verify(mockCallback).invoke(captor.capture())
         captor.firstValue shouldBeInstanceOf InAppMessagingException::class.java


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
