### PR TITLE
improvement: update ClassNotFoundException log type in analytics module 

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/EventTrackerHelper.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/EventTrackerHelper.kt
@@ -42,7 +42,7 @@ internal object EventTrackerHelper {
             Class.forName(className)
             true
         } catch (e: ClassNotFoundException) {
-            Timber.tag(TAG).e(e)
+            Timber.tag(TAG).i(e)
             false
         }
     }


### PR DESCRIPTION
Update the `ClassNotFoundException` to info exception, to avoid showing error logs every time an event is sent when the host app doesn't implement Analytics SDK dependencies.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
