### PR TITLE
fix: update Picasso memory cache config

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/CacheUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/CacheUtil.kt
@@ -1,0 +1,16 @@
+package com.rakuten.tech.mobile.inappmessaging.runtime.utils
+
+internal object CacheUtil {
+
+    /**
+     * @return 1/8th of the given memory in byte.
+     */
+    fun getMemoryCacheSize(memory: Int = getMaxMemory()): Int = if (memory > 0) memory / 8 else 1
+
+    /**
+     * @return the available VM memory in byte.
+     * Get max available VM memory, exceeding this amount will throw an
+     * OutOfMemory exception.
+     */
+    private fun getMaxMemory() = Runtime.getRuntime().maxMemory().toInt()
+}

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -12,6 +12,7 @@ import com.google.gson.Gson
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
+import com.squareup.picasso.LruCache
 import com.squareup.picasso.Picasso
 import timber.log.Timber
 import java.lang.ClassCastException
@@ -129,10 +130,23 @@ internal object Initializer {
 
             val picasso = Picasso.Builder(context)
                 .downloader(OkHttp3Downloader(client))
+                .memoryCache(LruCache(getMemoryCacheSize()))
                 .build()
             Picasso.setSingletonInstance(picasso)
         } catch (ignored: IllegalStateException) {
             // Picasso instance was already initialized
         }
+    }
+
+    /**
+     * @return 1/8th of the available VM memory in byte.
+     */
+    private fun getMemoryCacheSize(): Int {
+
+        // Get max available VM memory, exceeding this amount will throw an
+        // OutOfMemory exception.
+        val maxMemory = (Runtime.getRuntime().maxMemory()).toInt()
+
+        return maxMemory / 8
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -12,6 +12,7 @@ import com.google.gson.Gson
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.CacheUtil.getMemoryCacheSize
 import com.squareup.picasso.LruCache
 import com.squareup.picasso.Picasso
 import timber.log.Timber
@@ -132,21 +133,11 @@ internal object Initializer {
                 .downloader(OkHttp3Downloader(client))
                 .memoryCache(LruCache(getMemoryCacheSize()))
                 .build()
+            picasso.isLoggingEnabled = true
+            picasso.setIndicatorsEnabled(true)
             Picasso.setSingletonInstance(picasso)
         } catch (ignored: IllegalStateException) {
             // Picasso instance was already initialized
         }
-    }
-
-    /**
-     * @return 1/8th of the available VM memory in byte.
-     */
-    private fun getMemoryCacheSize(): Int {
-
-        // Get max available VM memory, exceeding this amount will throw an
-        // OutOfMemory exception.
-        val maxMemory = (Runtime.getRuntime().maxMemory()).toInt()
-
-        return maxMemory / 8
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/CacheUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/CacheUtilSpec.kt
@@ -1,0 +1,29 @@
+package com.rakuten.tech.mobile.inappmessaging.runtime.utils
+
+import android.os.Build
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBePositive
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+@RunWith(RobolectricTestRunner::class)
+class CacheUtilSpec {
+
+    @Test
+    fun `should return 1 if cache size is less than 0`() {
+        CacheUtil.getMemoryCacheSize(-1).shouldBeEqualTo(1)
+    }
+
+    @Test
+    fun `should return 1 if cache size is equal 0`() {
+        CacheUtil.getMemoryCacheSize(0).shouldBeEqualTo(1)
+    }
+
+    @Test
+    fun `should return positive cache size`() {
+        CacheUtil.getMemoryCacheSize().shouldBePositive()
+    }
+}


### PR DESCRIPTION
Update Picasso memory cache config to avoid OutOfMemory exception.

## Links
[SDKCF-4661]

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
