### PR TITLE
refactor: remove picasso cache indicator

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -133,8 +133,6 @@ internal object Initializer {
                 .downloader(OkHttp3Downloader(client))
                 .memoryCache(LruCache(getMemoryCacheSize()))
                 .build()
-            picasso.isLoggingEnabled = true
-            picasso.setIndicatorsEnabled(true)
             Picasso.setSingletonInstance(picasso)
         } catch (ignored: IllegalStateException) {
             // Picasso instance was already initialized

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtilSpec.kt
@@ -43,7 +43,6 @@ class ImageUtilSpec {
     private fun initializePicassoInstance() {
         try {
             val picasso = Picasso.Builder(context).build()
-            picasso.isLoggingEnabled = true
             Picasso.setSingletonInstance(picasso)
         } catch (ignored: IllegalStateException) {
             // Picasso instance was already initialized


### PR DESCRIPTION
# Description
[SDKCF-4677] Remove picasso cache indicator and loging.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
