### PR TITLE
fix: change bitmap retrieval to normal picasso fetch to improve performance (SDKCF-4684)

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
@@ -18,9 +18,7 @@ import kotlinx.coroutines.Runnable
 @UiThread
 internal class DisplayMessageRunnable(
     private val message: Message,
-    private val hostActivity: Activity,
-    private val imageWidth: Int = 0,
-    private val imageHeight: Int = 0
+    private val hostActivity: Activity
 ) : Runnable {
 
     /**
@@ -42,7 +40,7 @@ internal class DisplayMessageRunnable(
                     val modalView = hostActivity
                             .layoutInflater
                             .inflate(R.layout.in_app_message_modal, null) as InAppMessageModalView
-                    modalView.populateViewData(message, imageWidth, imageHeight)
+                    modalView.populateViewData(message)
                     hostActivity.addContentView(modalView, hostActivity.window.attributes)
                 }
                 InAppMessageType.FULL -> {
@@ -51,7 +49,7 @@ internal class DisplayMessageRunnable(
                             .inflate(
                                     R.layout.in_app_message_full_screen,
                                     null) as InAppMessageFullScreenView
-                    fullScreenView.populateViewData(message, imageWidth, imageHeight)
+                    fullScreenView.populateViewData(message)
                     hostActivity.addContentView(fullScreenView, hostActivity.window.attributes)
                 }
                 InAppMessageType.SLIDE -> {
@@ -60,7 +58,7 @@ internal class DisplayMessageRunnable(
                             .inflate(
                                     R.layout.in_app_message_slide_up,
                                     null) as InAppMessageSlideUpView
-                    slideUpView.populateViewData(message, imageWidth, imageHeight)
+                    slideUpView.populateViewData(message)
                     hostActivity.addContentView(slideUpView, hostActivity.window.attributes)
                 }
                 else -> Any()

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt
@@ -3,10 +3,8 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.service
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Looper
-import androidx.annotation.VisibleForTesting
 import androidx.core.app.JobIntentService
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ImageUtil
@@ -15,7 +13,10 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.LocalDis
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ReadyForDisplayMessageRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.runnable.DisplayMessageRunnable
+import com.squareup.picasso.Callback
+import com.squareup.picasso.Picasso
 import timber.log.Timber
+import java.lang.Exception
 
 /**
  * Since one service is essentially one worker thread, so there's no chance multiple worker threads
@@ -26,6 +27,7 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
     var readyMessagesRepo = ReadyForDisplayMessageRepository.instance()
     var messageReadinessManager = MessageReadinessManager.instance()
     var handler = Handler(Looper.getMainLooper())
+    var picasso: Picasso? = null
 
     /**
      * This method starts displaying message runnable.
@@ -48,7 +50,6 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
             if (!imageUrl.isNullOrEmpty()) {
                     fetchImageThenDisplayMessage(message, hostActivity, imageUrl)
             } else {
-
                     // If no image, just display the message.
                     displayMessage(message, hostActivity)
             }
@@ -64,19 +65,21 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
         hostActivity: Activity,
         imageUrl: String
     ) {
-        val bitmap: Bitmap? = getImage(imageUrl)
-        bitmap?.let {
-            displayMessage(message, hostActivity, it.width, it.height)
-        }
-    }
+        ImageUtil.fetchImage(imageUrl, object : Callback {
+            override fun onSuccess() {
+                displayMessage(message, hostActivity)
+            }
 
-    @VisibleForTesting
-    internal fun getImage(imageUrl: String): Bitmap? = ImageUtil.fetchBitmap(imageUrl)
+            override fun onError(e: Exception?) {
+                Timber.tag(TAG).d("Downloading image failed")
+            }
+        }, hostActivity, picasso)
+    }
 
     /**
      * This method displays message on UI thread.
      */
-    private fun displayMessage(message: Message, hostActivity: Activity, imageWidth: Int = 0, imageHeight: Int = 0) {
+    private fun displayMessage(message: Message, hostActivity: Activity) {
         if (!verifyContexts(message)) {
             // Message display aborted by the host app
             Timber.tag(TAG).d("message display cancelled by the host app")
@@ -88,7 +91,7 @@ internal class DisplayMessageJobIntentService : JobIntentService() {
             return
         }
 
-        handler.post(DisplayMessageRunnable(message, hostActivity, imageWidth, imageHeight))
+        handler.post(DisplayMessageRunnable(message, hostActivity))
     }
 
     /**

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtil.kt
@@ -1,19 +1,14 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
-import android.graphics.Bitmap
+import android.content.Context
+import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
-import timber.log.Timber
-import java.lang.Exception
 
 internal object ImageUtil {
-    private const val TAG = "IAM_ImageUtil"
 
     @SuppressWarnings("TooGenericExceptionCaught")
-    fun fetchBitmap(imageUrl: String): Bitmap? =
-        try {
-            Picasso.get().load(imageUrl).priority(Picasso.Priority.HIGH).get()
-        } catch (e: Exception) {
-            Timber.tag(TAG).d(e, "Error on loading image $imageUrl")
-            null
-        }
+    fun fetchImage(imageUrl: String, callback: Callback, context: Context, picasso: Picasso? = null) {
+        (picasso ?: Picasso.get()).load(imageUrl).priority(Picasso.Priority.HIGH)
+            .resize(ViewUtil.getDisplayWidth(context), 0).fetch(callback)
+    }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtil.kt
@@ -6,7 +6,6 @@ import com.squareup.picasso.Picasso
 
 internal object ImageUtil {
 
-    @SuppressWarnings("TooGenericExceptionCaught")
     fun fetchImage(imageUrl: String, callback: Callback, context: Context, picasso: Picasso? = null) {
         (picasso ?: Picasso.get()).load(imageUrl).priority(Picasso.Priority.HIGH)
             .resize(ViewUtil.getDisplayWidth(context), 0).fetch(callback)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
@@ -12,13 +12,13 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.ImageView
+import androidx.annotation.VisibleForTesting
 import androidx.core.widget.NestedScrollView
 import com.google.android.material.button.MaterialButton
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.MessageButton
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ViewUtil.getDisplayHeight
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ViewUtil.getDisplayWidth
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ViewUtil
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import timber.log.Timber
@@ -43,14 +43,14 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
     private var messageBody: String? = null
     private var buttons: List<MessageButton>? = null
     private var displayOptOut = false
-    private var imageWidth = 0
-    private var imageHeight = 0
+    @VisibleForTesting
+    internal var picasso: Picasso? = null
 
     /**
      * Sets campaign message data onto the view.
      */
     @SuppressWarnings("LongMethod")
-    override fun populateViewData(message: Message, imageWidth: Int, imageHeight: Int) {
+    override fun populateViewData(message: Message) {
         try {
             this.headerColor = Color.parseColor(message.getMessagePayload().headerColor)
             this.messageBodyColor = Color.parseColor(message.getMessagePayload().messageBodyColor)
@@ -63,8 +63,6 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
             this.messageBodyColor = Color.BLACK
             this.bgColor = Color.WHITE
         }
-        this.imageWidth = getDisplayWidth(context)
-        this.imageHeight = getDisplayHeight(context, imageWidth, imageHeight)
         this.header = message.getMessagePayload().header
         this.messageBody = message.getMessagePayload().messageBody
         this.buttons = message.getMessagePayload().messageSettings.controlSettings.buttons
@@ -148,9 +146,9 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
                             Timber.tag(TAG).d(e?.cause, "Downloading image failed $imageUrl")
                         }
                     }
-                    Picasso.get().load(this.imageUrl)
+                    (picasso ?: Picasso.get()).load(this.imageUrl)
                         .priority(Picasso.Priority.HIGH)
-                        .resize(this.imageWidth, this.imageHeight)
+                        .resize(ViewUtil.getDisplayWidth(context), 0)
                         .onlyScaleDown()
                         .centerInside()
                         .into(it, callback)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageFullScreenView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageFullScreenView.kt
@@ -19,8 +19,8 @@ internal class InAppMessageFullScreenView(
     /**
      * Populating view data.
      */
-    override fun populateViewData(message: Message, imageWidth: Int, imageHeight: Int) {
-        super.populateViewData(message, imageWidth, imageHeight)
+    override fun populateViewData(message: Message) {
+        super.populateViewData(message)
         if (imageUrl.isNullOrEmpty()) {
             // If no image, use @drawable/close_button_black_background.
             findViewById<ImageButton>(R.id.message_close_button)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageModalView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageModalView.kt
@@ -18,8 +18,8 @@ internal class InAppMessageModalView(
     /**
      * Sets campaign message data onto the view.
      */
-    override fun populateViewData(message: Message, imageWidth: Int, imageHeight: Int) {
-        super.populateViewData(message, imageWidth, imageHeight)
+    override fun populateViewData(message: Message) {
+        super.populateViewData(message)
         findViewById<LinearLayout>(R.id.modal)?.setBackgroundColor(bgColor)
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageSlideUpView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageSlideUpView.kt
@@ -21,8 +21,8 @@ internal class InAppMessageSlideUpView(
     /**
      * Populating view data according to Slide Up view.
      */
-    override fun populateViewData(message: Message, imageWidth: Int, imageHeight: Int) {
-        super.populateViewData(message, imageWidth, imageHeight)
+    override fun populateViewData(message: Message) {
+        super.populateViewData(message)
 
         // Override image from white background to black background.
         findViewById<ImageButton>(R.id.message_close_button)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageView.kt
@@ -10,5 +10,5 @@ internal interface InAppMessageView {
      * This method sets campaign message data int the custom view classes.
      * Message must not be null.
      */
-    fun populateViewData(message: Message, imageWidth: Int = 0, imageHeight: Int = 0)
+    fun populateViewData(message: Message)
 }


### PR DESCRIPTION
# Description
Bitmal retrieval causes the OOM in low memory device.
To avoid this, the SDK will use normal fetch and use device width for resizing.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
