### PR TITLE
ci: set java version to 11 when running sonarqube

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -159,6 +159,9 @@ workflows:
             fi
   _run-sonarqube-scanner:
     steps:
+    - set-java-version@1:
+        inputs:
+        - set_java_version: '11'
     - script@1:
         run_if: '{{getenv "SONARQUBE_TOKEN" | ne ""}}'
         title: Run SonarQube Scanner

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 plugins {
     id 'net.ltgt.errorprone' version '1.3.0' apply false
     id 'io.gitlab.arturbosch.detekt' version '1.1.1'
-    id 'org.sonarqube' version '3.2.0'
+    id 'org.sonarqube' version '3.3'
 }
 
 allprojects { proj ->


### PR DESCRIPTION
# Description
Current sonarqube instance requires analysis to build in Java 11