### PR TITLE
fix: add handling for tooltip that are over the edge of device

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtil.kt
@@ -74,6 +74,23 @@ internal object ViewUtil {
         }
     }
 
+    fun getEdgePosition(width: Int, height: Int, topPos: Pair<Int, Int>): Pair<Int?, Int?> {
+        val windowW = Resources.getSystem().displayMetrics.widthPixels
+        val windowH = Resources.getSystem().displayMetrics.heightPixels
+        val right = if (windowW < (topPos.first + width)) {
+            -(width - (windowW - topPos.first)) - PADDING - TRI_SIZE
+        } else {
+            null
+        }
+
+        val bottom = if (windowH < (topPos.second + height)) {
+            -(height - (windowH - topPos.second)) - PADDING - TRI_SIZE
+        } else {
+            null
+        }
+        return Pair(right, bottom)
+    }
+
     @SuppressWarnings("SwallowedException")
     fun getScrollView(view: View): FrameLayout? {
         var currView = view.parent

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessagingTooltipView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessagingTooltipView.kt
@@ -303,10 +303,21 @@ internal class InAppMessagingTooltipView(
                     view, type, imageView.layoutParams.width, imageView.layoutParams.height, buttonSize, buttonSize
                 )
                     .let { pos ->
-                        params.topMargin = pos.second
-                        params.leftMargin = pos.first
+                        setPosition(params, pos, imageView.layoutParams.width, imageView.layoutParams.height)
                     }
             }
+        }
+    }
+
+    internal fun setPosition(params: MarginLayoutParams, pos: Pair<Int, Int>, width: Int, height: Int) {
+        params.topMargin = pos.second
+        params.leftMargin = pos.first
+        val edgePos = ViewUtil.getEdgePosition(width, height, pos)
+        edgePos.first?.let { right ->
+            params.rightMargin = right
+        }
+        edgePos.second?.let { bottom ->
+            params.bottomMargin = bottom
         }
     }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtilSpec.kt
@@ -167,6 +167,20 @@ class ViewUtilSpec : BaseTest() {
         ViewUtil.getScrollView(mockView).shouldNotBeNull()
     }
 
+    @Test
+    fun `should return correct non-null right and bottom edge position`() {
+        val pos = ViewUtil.getEdgePosition(500, 500, POS)
+        pos.first.shouldNotBeNull()
+        pos.second.shouldNotBeNull()
+    }
+
+    @Test
+    fun `should return correct null right and bottom edge position`() {
+        val pos = ViewUtil.getEdgePosition(10, 10, POS)
+        pos.first.shouldBeNull()
+        pos.second.shouldBeNull()
+    }
+
     private fun setupPosition(type: PositionType): Pair<Int, Int> {
         val mockView = Mockito.mock(View::class.java)
         `when`(mockView.width).thenReturn(10)
@@ -184,5 +198,6 @@ class ViewUtilSpec : BaseTest() {
         private const val HEIGHT = 10
         private const val MARGIN_H = 10
         private const val MARGIN_V = 10
+        private val POS = Pair(100, 100)
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessagingTooltipViewSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessagingTooltipViewSpec.kt
@@ -166,6 +166,26 @@ class InAppMessagingTooltipViewSpec {
         view?.type shouldBeEqualTo PositionType.TOP_CENTER
     }
 
+    @Test
+    fun `should set top and left params only`() {
+        val params = ViewGroup.MarginLayoutParams(10, 10)
+        view?.setPosition(params, Pair(100, 100), 200, 200)
+        params.topMargin shouldBeEqualTo 100
+        params.leftMargin shouldBeEqualTo 100
+        params.bottomMargin shouldBeEqualTo 0
+        params.rightMargin shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `should set all margin params`() {
+        val params = ViewGroup.MarginLayoutParams(10, 10)
+        view?.setPosition(params, Pair(10, 10), 500, 500)
+        params.topMargin shouldBeEqualTo 10
+        params.leftMargin shouldBeEqualTo 10
+        params.bottomMargin shouldBeEqualTo -100
+        params.rightMargin shouldBeEqualTo -250
+    }
+
     private fun verifyImageFetch(
         isValid: Boolean,
         isException: Boolean = false,


### PR DESCRIPTION
# Description
image in tooltip layout is in disrupted when part of the campaign is over the right or bottom edge of the device 

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
