### PR TITLE
improve: draw button's border if it has the same bg color as campaign (SDKCF-4859)

### DIFF
--- a/inappmessaging/src/main/res/values/colors.xml
+++ b/inappmessaging/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <color name="in_app_message_frame_light">#5F333333</color>
+  <color name="modal_border_color_light_grey">#D1D1D1</color>
 </resources>

--- a/inappmessaging/src/main/res/values/dimens.xml
+++ b/inappmessaging/src/main/res/values/dimens.xml
@@ -17,7 +17,7 @@
 
   <!--Modal Button-->
   <dimen name="modal_button_height">53dp</dimen>
-  <dimen name="modal_button_boarder_stroke_width">1dp</dimen>
+  <dimen name="modal_button_border_stroke_width">0.5dp</dimen>
   <dimen name="modal_button_corner_radius">4dp</dimen>
   <dimen name="modal_button_double_margin_left_right">8dp</dimen>
   <dimen name="modal_button_double_margin_top_bottom">24dp</dimen>

--- a/inappmessaging/src/main/res/values/styles.xml
+++ b/inappmessaging/src/main/res/values/styles.xml
@@ -40,6 +40,7 @@
     <item name="backgroundTint">@android:color/holo_orange_light</item>
     <item name="backgroundTintMode">src_over</item>
     <item name="cornerRadius">@dimen/modal_button_corner_radius</item>
+    <item name="strokeColor">@color/modal_border_color_light_grey</item>
     <item name="android:textAllCaps">false</item>
     <item name="android:layout_height">@dimen/modal_button_height</item>
     <item name="android:includeFontPadding">false</item>

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
@@ -217,6 +217,62 @@ class BaseViewSpec : BaseTest() {
         view?.findViewById<MaterialButton>(R.id.message_single_button)?.typeface.shouldNotBeNull()
     }
 
+    @Test
+    fun `should set button border for identical bg colors`() {
+        val bgColor = "#AA00BB"
+        `when`(mockPayload.headerColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.messageBodyColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.backgroundColor).thenReturn(bgColor)
+        view?.populateViewData(mockMessage)
+
+        val mockButton = Mockito.mock(MaterialButton::class.java)
+        view?.setButtonBorder(mockButton, Color.parseColor(bgColor), Color.BLACK)
+        Mockito.verify(mockButton, times(1)).setStrokeColor(ColorStateList.valueOf(Color.BLACK))
+        Mockito.verify(mockButton, times(1)).setStrokeWidth(any())
+    }
+
+    @Test
+    fun `should set button border for similar bg colors`() {
+        `when`(mockPayload.headerColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.messageBodyColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.backgroundColor).thenReturn("#AA00BB")
+        view?.populateViewData(mockMessage)
+
+        val mockButton = Mockito.mock(MaterialButton::class.java)
+        view?.setButtonBorder(mockButton, Color.parseColor("#AA05BB"), Color.BLACK)
+        Mockito.verify(mockButton, times(1)).setStrokeColor(ColorStateList.valueOf(Color.BLACK))
+        Mockito.verify(mockButton, times(1)).setStrokeWidth(any())
+    }
+
+    @Test
+    fun `should set grey button border for white bg colors`() {
+        `when`(mockPayload.headerColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.messageBodyColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.backgroundColor).thenReturn(WHITE_HEX)
+        view?.populateViewData(mockMessage)
+
+        val mockButton = Mockito.mock(MaterialButton::class.java)
+        view?.setButtonBorder(mockButton, Color.parseColor(WHITE_HEX), Color.BLACK)
+        val expectedColor = view?.resources?.getColorStateList(
+            R.color.modal_border_color_light_grey, view!!.context.theme
+        )
+        Mockito.verify(mockButton, times(1)).setStrokeColor(expectedColor)
+        Mockito.verify(mockButton, times(1)).setStrokeWidth(any())
+    }
+
+    @Test
+    fun `should not set button border for different bg colors`() {
+        `when`(mockPayload.headerColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.messageBodyColor).thenReturn(WHITE_HEX)
+        `when`(mockPayload.backgroundColor).thenReturn(WHITE_HEX)
+        view?.populateViewData(mockMessage)
+
+        val mockButton = Mockito.mock(MaterialButton::class.java)
+        view?.setButtonBorder(mockButton, Color.parseColor("#AA00BB"), Color.BLACK)
+        Mockito.verify(mockButton, never()).setStrokeColor(any())
+        Mockito.verify(mockButton, never()).setStrokeWidth(any())
+    }
+
     @SuppressWarnings("LongMethod")
     private fun setupMockContext(
         isInvalid: Boolean = false,


### PR DESCRIPTION
# Description
Action button should have a border when campaign body has the same background color.
<img src="https://user-images.githubusercontent.com/13205475/160302699-6295e179-bb5f-4280-aa43-4a763b38bbf9.png" width="200" />

## Links
SDKCF-4859

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [X] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [X] I ran `./gradlew check` without errors
