### PR TITLE
fix: Slide up message: fix spacing when close button is hidden (SDKCF-5002)

### DIFF
--- a/inappmessaging/src/main/res/layout/in_app_message_slide_up.xml
+++ b/inappmessaging/src/main/res/layout/in_app_message_slide_up.xml
@@ -34,21 +34,25 @@
       style="@style/InAppMessaging.Text.Slide"
       android:layout_width="0dp"
       android:layout_height="match_parent"
-      android:layout_marginTop="@dimen/slide_up_text_margin_top"
+      android:layout_marginEnd="@dimen/slide_up_text_margin_end"
+      android:paddingTop="@dimen/slide_up_text_margin_top"
+      android:paddingBottom="@dimen/slide_up_text_margin_bottom"
       android:minHeight="@dimen/slide_up_text_min_height"
       app:layout_constraintLeft_toLeftOf="@id/left_guideline"
-      app:layout_constraintRight_toRightOf="@id/right_guideline"
+      app:layout_constraintRight_toLeftOf="@id/message_close_button"
       tools:text="@string/example_body_text"
-      tools:visibility="visible" />
+      tools:visibility="visible"/>
 
     <ImageButton
       android:id="@+id/message_close_button"
       style="@style/InAppMessaging.CloseButton.SlideUp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="1.0"
-      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintStart_toStartOf="@id/right_guideline"
       app:layout_constraintTop_toTopOf="parent"
-      android:contentDescription="@string/close_button" />
+      android:contentDescription="@string/close_button"
+      android:visibility="visible"/>
+
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/inappmessaging/src/main/res/values/dimens.xml
+++ b/inappmessaging/src/main/res/values/dimens.xml
@@ -44,7 +44,9 @@
 
   <!--Slide Up Text -->
   <dimen name="slide_up_text_min_height">50dp</dimen>
-  <dimen name="slide_up_text_margin_top">0dp</dimen>
+  <dimen name="slide_up_text_margin_top">8dp</dimen>
+  <dimen name="slide_up_text_margin_bottom">8dp</dimen>
+  <dimen name="slide_up_text_margin_end">4dp</dimen>
 
   <!--Message OptOut checkbox-->
   <dimen name="opt_out_text_size">12sp</dimen>


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/77660332/162359177-3efcf5a5-24b2-4dc3-86fa-a490c781da54.png" width="200">     <img src="https://user-images.githubusercontent.com/77660332/162359205-6bc7424c-d76d-44f3-b0d5-6cbe956d472c.png" width="200">

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
