### PR TITLE
fix: use wider stroke width for button border (SDKCF-4859)

### DIFF
--- a/inappmessaging/src/main/res/values/dimens.xml
+++ b/inappmessaging/src/main/res/values/dimens.xml
@@ -17,7 +17,7 @@
 
   <!--Modal Button-->
   <dimen name="modal_button_height">53dp</dimen>
-  <dimen name="modal_button_border_stroke_width">0.5dp</dimen>
+  <dimen name="modal_button_border_stroke_width">1dp</dimen>
   <dimen name="modal_button_corner_radius">4dp</dimen>
   <dimen name="modal_button_double_margin_left_right">8dp</dimen>
   <dimen name="modal_button_double_margin_top_bottom">24dp</dimen>


### PR DESCRIPTION
# Description
0.5dp is too thin

## Links
SDKCF-4859

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [X] I ran `./gradlew check` without errors
