### PR TITLE
fix: add missing DependencyCheck job to build and test workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -23,6 +23,10 @@ workflows:
         inputs:
         - content: ./gradlew androidDependencies
     - script@1:
+        title: Dependency Check
+        inputs:
+        - content: ./gradlew dependencyCheckAggregate
+    - script@1:
         title: Run Check
         inputs:
         - content: ./gradlew check


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
