### PR TITLE
fix: Sonarqube Dependencycheck report display

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         classpath 'pl.allegro.tech.build:axion-release-plugin:1.13.6'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
-        classpath 'org.owasp:dependency-check-gradle:6.5.3'
+        classpath 'org.owasp:dependency-check-gradle:7.1.0.1'
     }
 }
 

--- a/dependency-check.gradle
+++ b/dependency-check.gradle
@@ -5,9 +5,8 @@ allprojects {
         skipProjects = [':test']
         // set the Common Vulnerability Scoring System value
         // https://nvd.nist.gov/vuln-metrics/cvss
-        failBuildOnCVSS = System.getenv("DEPENDENCY_CHECK_FAILBUID_CVSS") as Integer
+        failBuildOnCVSS = System.getenv("DEPENDENCY_CHECK_FAILBUID_CVSS") as Float
         suppressionFile = 'dependency_check_suppressions.xml'
-        outputDirectory = 'build/reports/dependency-check'
         formats = ['JSON', 'HTML']
         showSummary true
     }

--- a/sonar.gradle
+++ b/sonar.gradle
@@ -22,8 +22,8 @@ sonarqube {
 
         /* Dependency Check */
         property 'sonar.dependencyCheck.skip', System.getenv("SONAR_DEPENDENCYCHECK_SKIP")
-        property 'sonar.dependencyCheck.jsonReportPath', 'build/reports/dependency-check/dependency-check-report.json'
-        property 'sonar.dependencyCheck.htmlReportPath', 'build/reports/dependency-check/dependency-check-report.html'
+        property 'sonar.dependencyCheck.jsonReportPath', 'build/reports/dependency-check-report.json'
+        property 'sonar.dependencyCheck.htmlReportPath', 'build/reports/dependency-check-report.html'
     }
 }
 


### PR DESCRIPTION
# Description
- Sonarqube doesn't display the report when the path to the generated report is customized -> Used the default  path
- Changed the type of CVSS score to float to be able to config more accurate value.
- Bumped Dependency check to v7.1.0.1

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
