### PR TITLE
chore: improve Bitrise' builds waiting time (SDKCF-5382)

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,13 @@
+tag_name = ENV['BITRISE_GIT_TAG']
+is_release = tag_name != nil && tag_name != ""
+
+message "Tag Name: #{tag_name}, Is Release: #{is_release}"
+
 # Warn when there is a big PR
 warn("Big PR") if git.lines_of_code > 1000
 
 # Code coverage
 jacoco.minimum_project_coverage_percentage = 80
-jacoco.report("inappmessaging/build/reports/jacoco/jacocoReleaseReport/jacocoReleaseReport.xml", fail_no_coverage_data_found: false)
+jacoco.report(is_release ? "inappmessaging/build/reports/jacoco/jacocoReleaseReport/jacocoReleaseReport.xml" :
+                           "inappmessaging/build/reports/jacoco/jacocoDebugReport/jacocoDebugReport.xml",
+                           fail_no_coverage_data_found: false)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,7 +1,7 @@
 tag_name = ENV['BITRISE_GIT_TAG']
 is_release = tag_name != nil && tag_name != ""
 
-message "Tag Name: #{tag_name}, Is Release: #{is_release}"
+message "Tag: #{tag_name}, Is Release: #{is_release}"
 
 # Warn when there is a big PR
 warn("Big PR") if git.lines_of_code > 1000

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -88,27 +88,27 @@ workflows:
     - _common-end
     - _publish-doc
     steps:
-      - script@1:
-          title: Run Check
-          inputs:
-            - content: "./gradlew check"
-      - script@1:
-          title: Assemble
-          inputs:
-            - content: "./gradlew assemble"
-      - script@1:
-          title: Current Version
-          inputs:
-            - content: "./gradlew currentVersion"
-      - custom-test-results-export@0:
-          inputs:
-            - test_name: Unit Tests (Release)
-            - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
-            - search_pattern: "*"
-      - deploy-to-bitrise-io@2:
-          inputs:
-            - deploy_path: "$SDK_PATH/build/outputs/aar"
-            - is_enable_public_page: 'false'
+    - script@1:
+        title: Run Check
+        inputs:
+        - content: "./gradlew check"
+    - script@1:
+        title: Assemble
+        inputs:
+        - content: "./gradlew assemble"
+    - script@1:
+        title: Current Version
+        inputs:
+        - content: "./gradlew currentVersion"
+    - custom-test-results-export@0:
+        inputs:
+        - test_name: Unit Tests (Release)
+        - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
+        - search_pattern: "*"
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$SDK_PATH/build/outputs/aar"
+        - is_enable_public_page: 'false'
     - script@1:
         title: Retrieve Base64 PGP Key and save to file
         inputs:
@@ -191,29 +191,29 @@ workflows:
         - content: ./gradlew sonarqube
   _common-start:
     steps:
-      - cache-pull@2: {}
-      - script@1:
-          title: Run Dependency Check
-          inputs:
-            - timeout: 1800
-            - content: "./gradlew dependencyCheckAggregate"
+    - cache-pull@2: {}
+    - script@1:
+        title: Run Dependency Check
+        inputs:
+        - timeout: 1800
+        - content: "./gradlew dependencyCheckAggregate"
   _common-end:
     after_run:
-      - _run-sonarqube-scanner
+    - _run-sonarqube-scanner
     steps:
-      - danger@2:
-          inputs:
-            - github_api_token: "$DANGER_GITHUB_API_TOKEN"
-      - cache-push@2:
-          inputs:
-            - cache_paths: |-
-                $HOME/.gradle
-                ./.gradle
-                $HOME/.m2
-            - ignore_check_on_paths: |-
-                $HOME/.gradle/caches/*.lock
-                ./.gradle/*.lock
-                ./.gradle/*.bin
+    - danger@2:
+        inputs:
+        - github_api_token: "$DANGER_GITHUB_API_TOKEN"
+    - cache-push@2:
+        inputs:
+        - cache_paths: |-
+            $HOME/.gradle
+            ./.gradle
+            $HOME/.m2
+        - ignore_check_on_paths: |-
+            $HOME/.gradle/caches/*.lock
+            ./.gradle/*.lock
+            ./.gradle/*.bin
 meta:
   bitrise.io:
     stack: linux-docker-android-20.04

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,7 +30,6 @@ workflows:
         inputs:
         - content: "./gradlew detektRelease lintAnalyzeDebug lintDebug lintReportDebug testDebugUnitTest jacocoDebugReport"
     - custom-test-results-export@0:
-        # this add-on should export test artifacts as well, but currently not displayed.
         inputs:
         - test_name: Unit Tests (Debug)
         - base_path: "$SDK_PATH/build/test-results/testDebugUnitTest/"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -20,66 +20,25 @@ workflows:
   build-and-test:
     before_run:
     - _setup-env
+    - _common-start
     after_run:
-    - _run-sonarqube-scanner
+    - _common-end
     steps:
     - cache-pull@2: {}
     - script@1:
-        title: Download Dependencies
+        title: Run some verification tasks
         inputs:
-        - content: ./gradlew androidDependencies
-    - script@1:
-        title: Dependency Check
-        inputs:
-        - content: ./gradlew dependencyCheckAggregate
-    - script@1:
-        title: Run Check
-        inputs:
-        - content: ./gradlew check
-    - danger@2:
-        inputs:
-        - github_api_token: "$DANGER_GITHUB_API_TOKEN"
-    - script@1:
-        title: Assemble
-        inputs:
-        - content: ./gradlew assemble
-    - script@1:
-        title: Current Version
-        inputs:
-        - content: ./gradlew currentVersion
+        - content: "./gradlew detektRelease lintAnalyzeDebug lintDebug lintReportDebug testDebugUnitTest jacocoDebugReport"
     - custom-test-results-export@0:
         # this add-on should export test artifacts as well, but currently not displayed.
         inputs:
         - test_name: Unit Tests (Debug)
         - base_path: "$SDK_PATH/build/test-results/testDebugUnitTest/"
         - search_pattern: "*"
-    - custom-test-results-export@0:
-        inputs:
-        - test_name: Unit Tests (Release)
-        - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
-        - search_pattern: "*"
-    - deploy-to-bitrise-io@2:
-        inputs:
-        - deploy_path: $SDK_PATH/build/outputs/aar
-        - is_enable_public_page: 'false'
-    - cache-push@2:
-        inputs:
-        - cache_paths: |-
-            $HOME/.gradle
-            ./.gradle
-            $HOME/.m2
-        - ignore_check_on_paths: |-
-            $HOME/.gradle/caches/*.lock
-            ./.gradle/*.lock
-            ./.gradle/*.bin
   integration-test:
     before_run:
     - _setup-env
     steps:
-    - script@1:
-        title: Download Dependencies
-        inputs:
-        - content: ./gradlew androidDependencies
     - script@1:
         title: Dependency Check
         inputs:
@@ -123,10 +82,33 @@ workflows:
         - color_on_error: "#d10b20"
   release:
     before_run:
-    - build-and-test
+    - _setup-env
+    - _common-start
     after_run:
+    - _common-end
     - _publish-doc
     steps:
+      - script@1:
+          title: Run Check
+          inputs:
+            - content: "./gradlew check"
+      - script@1:
+          title: Assemble
+          inputs:
+            - content: "./gradlew assemble"
+      - script@1:
+          title: Current Version
+          inputs:
+            - content: "./gradlew currentVersion"
+      - custom-test-results-export@0:
+          inputs:
+            - test_name: Unit Tests (Release)
+            - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
+            - search_pattern: "*"
+      - deploy-to-bitrise-io@2:
+          inputs:
+            - deploy_path: "$SDK_PATH/build/outputs/aar"
+            - is_enable_public_page: 'false'
     - script@1:
         title: Retrieve Base64 PGP Key and save to file
         inputs:
@@ -173,9 +155,6 @@ workflows:
             fi
   _run-sonarqube-scanner:
     steps:
-    - set-java-version@1:
-        inputs:
-        - set_java_version: '11'
     - script@1:
         title: Prepare branches to feed in sonar.gradle
         description: This step ensures that source and destination branches exist. For sonarqube to work, the current working branch should be the source branch.
@@ -210,6 +189,31 @@ workflows:
         title: Run SonarQube Scanner
         inputs:
         - content: ./gradlew sonarqube
+  _common-start:
+    steps:
+      - cache-pull@2: {}
+      - script@1:
+          title: Run Dependency Check
+          inputs:
+            - timeout: 1800
+            - content: "./gradlew dependencyCheckAggregate"
+  _common-end:
+    after_run:
+      - _run-sonarqube-scanner
+    steps:
+      - danger@2:
+          inputs:
+            - github_api_token: "$DANGER_GITHUB_API_TOKEN"
+      - cache-push@2:
+          inputs:
+            - cache_paths: |-
+                $HOME/.gradle
+                ./.gradle
+                $HOME/.m2
+            - ignore_check_on_paths: |-
+                $HOME/.gradle/caches/*.lock
+                ./.gradle/*.lock
+                ./.gradle/*.bin
 meta:
   bitrise.io:
     stack: linux-docker-android-20.04

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ application_id=com.rakuten.tech.mobile.inappmessaging
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableD8=true
+
+org.gradle.parallel=true

--- a/sonar.gradle
+++ b/sonar.gradle
@@ -4,6 +4,7 @@ def branch = System.getenv("BITRISE_GIT_BRANCH")
 def pRBranch = System.getenv("BITRISE_PULL_REQUEST")
 def pRTargetBranch = System.getenv("BITRISEIO_GIT_BRANCH_DEST")
 def tagName = System.getenv("BITRISE_GIT_TAG")
+def isRelease = tagName != null && tagName != ""
 
 sonarqube {
     properties {
@@ -14,7 +15,7 @@ sonarqube {
         property 'sonar.projectKey', System.getenv("SONARQUBE_PROJ_KEY")
         property 'sonar.projectVersion', scmVersion.version
         /* Tags */
-        if (tagName != null && tagName != "") {
+        if (isRelease) {
             // Since tags don't have an explicit branch and can point to any commit, let us use the tag name
             // as branch name property. In Sonarqube, the tag is going to appear same level as other branches
             // with its own analysis.
@@ -55,8 +56,12 @@ subprojects { subproject ->
                                             '**/.gradle/**, ' +
                                             '**/R.class'
             property 'sonar.test.inclusions', '**/test/**'
-            property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/jacocoReleaseReport/jacocoReleaseReport.xml'
-            property 'sonar.junit.reportPaths', 'build/test-results/testReleaseUnitTest'
+            property 'sonar.coverage.jacoco.xmlReportPaths', 
+                    isRelease ? 'build/reports/jacoco/jacocoReleaseReport/jacocoReleaseReport.xml' :
+                                'build/reports/jacoco/jacocoDebugReport/jacocoDebugReport.xml'
+            property 'sonar.junit.reportPaths',
+                    isRelease ? 'build/test-results/testReleaseUnitTest' :
+                                'build/test-results/testDebugUnitTest'
         }
     }
 }


### PR DESCRIPTION
# Description
Broken down `gradlew check` so that verification tasks will only run for debug variant. Full check (with other variants release, releaseMinified) will be done on release only.

## Links
SDKCF-5382

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
