### PR TITLE
fix: opt-out status not working for "" (anonymous) users (SDKCF-5593)

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/CampaignRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/CampaignRepository.kt
@@ -36,11 +36,6 @@ internal interface CampaignRepositoryType {
     fun incrementImpressions(id: String): Message?
 
     /**
-     * Loads campaign data from user cache.
-     */
-    fun loadCachedData()
-
-    /**
      * Clears [messages] for last user.
      */
     fun clearMessages()
@@ -74,6 +69,7 @@ internal abstract class CampaignRepository : CampaignRepositoryType {
         @SuppressWarnings("LongMethod", "NestedBlockDepth")
         override fun syncWith(messageList: List<Message>, timestampMillis: Long) {
             lastSyncMillis = timestampMillis
+            loadCachedData() // ensure we're using latest cache data for syncing below
             val oldList = LinkedHashMap(messages) // copy
 
             messages.clear()
@@ -148,7 +144,7 @@ internal abstract class CampaignRepository : CampaignRepositoryType {
         }
 
         @SuppressWarnings("LongMethod", "TooGenericExceptionCaught")
-        override fun loadCachedData() {
+        private fun loadCachedData() {
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
                 val listString = try {
                     InAppMessaging.instance().getHostAppContext()?.let { ctx ->

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/SessionManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/SessionManager.kt
@@ -31,9 +31,6 @@ internal object SessionManager {
         // Clear any stale user cache structure if applicable
         AccountRepository.instance().clearUserOldCacheStructure()
 
-        // Load any cached campaigns of new user
-        CampaignRepository.instance().loadCachedData()
-
         // reset current delay to initial
         // future update: possibly add checking if last ping is within a certain threshold before executing the request
         MessageMixerPingScheduler.currDelay = RetryDelayUtil.INITIAL_BACKOFF_DELAY


### PR DESCRIPTION
## Description
Cached data not loaded for anonymous user after app is restarted

## Links
SDKCF-5593

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
