### PR TITLE
refactor: add handling for opt-out font color when background is dark (SDKCF-5242)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -389,6 +389,7 @@ Documents targeting Product Managers:
 
 ### 7.2.0 (in progress)
 * SDKCF-5510: Updated SDK Utils dependency to v2.0.0.
+* SDKCF-5242: Added handling to change opt-out color when background is dark.
 
 ### 7.1.0 (2022-06-24)
 * SDKCF-5256: Added sending of impression events with campaign details to analytics account.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageBaseView.kt
@@ -32,7 +32,7 @@ import kotlin.math.round
 /**
  * Base class of all custom views.
  */
-@SuppressWarnings("LargeClass")
+@SuppressWarnings("LargeClass", "TooManyFunctions")
 internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?) :
     FrameLayout(context, attrs), InAppMessageView {
 
@@ -139,6 +139,11 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
         // Display opt-out checkbox.
         if (this.displayOptOut) {
             val checkBox = findViewById<CheckBox>(R.id.opt_out_checkbox)
+            val brightness = getBrightness(bgColor)
+            if (brightness < BRIGHTNESS_LEVEL) {
+                checkBox.buttonTintList = ColorStateList.valueOf(Color.WHITE)
+                checkBox.setTextColor(Color.WHITE)
+            }
             checkBox?.setOnClickListener(this.listener)
             checkBox?.visibility = View.VISIBLE
         }
@@ -247,20 +252,24 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
     }
 
     // Set close button to black background if the campaign background color is dark.
-    // Brightness is computed based on [Darel Rex Finley's HSP Colour Model](http://alienryderflex.com/hsp.html).
-    // Computed value is from 0 (black) to 255 (white), and is considered dark if less than 130.
-    @SuppressWarnings("MagicNumber")
     internal fun setCloseButton(button: ImageButton? = null) {
         if (isDismissable) {
-            val red = Color.red(bgColor)
-            val green = Color.green(bgColor)
-            val blue = Color.blue(bgColor)
-            val brightness = sqrt((red * red * .241) + (green * green * .691) + (blue * blue * .068)).toInt()
-            if (brightness < 130) {
+            val brightness = getBrightness(bgColor)
+            if (brightness < BRIGHTNESS_LEVEL) {
                 (button ?: findViewById(R.id.message_close_button))
                     ?.setImageResource(R.drawable.close_button_white)
             }
         }
+    }
+
+    // Brightness is computed based on [Darel Rex Finley's HSP Colour Model](http://alienryderflex.com/hsp.html).
+    // Computed value is from 0 (black) to 255 (white), and is considered dark if less than 130.
+    @SuppressWarnings("MagicNumber")
+    private fun getBrightness(color: Int): Int {
+        val red = Color.red(color)
+        val green = Color.green(color)
+        val blue = Color.blue(color)
+        return sqrt((red * red * .241) + (green * green * .691) + (blue * blue * .068)).toInt()
     }
 
     // Set button's border based on similarity between its background color and campaign's background color.
@@ -319,5 +328,6 @@ internal open class InAppMessageBaseView(context: Context, attrs: AttributeSet?)
         private const val BUTTON_FONT = "iam_custom_font_button"
         private const val HEADER_FONT = "iam_custom_font_header"
         private const val BODY_FONT = "iam_custom_font_body"
+        private const val BRIGHTNESS_LEVEL = 130
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
@@ -120,6 +120,16 @@ class BaseViewSpec : BaseTest() {
         verifyCloseButton(WHITE_HEX, never())
     }
 
+    @Test
+    fun `should set check box to white color`() {
+        verifyCheckBox(BLACK_HEX, Color.WHITE)
+    }
+
+    @Test
+    fun `should set check box to black color`() {
+        verifyCheckBox(WHITE_HEX, Color.BLACK)
+    }
+
     private fun verifyCloseButton(color: String, mode: VerificationMode) {
         `when`(mockPayload.headerColor).thenReturn(color)
         `when`(mockPayload.messageBodyColor).thenReturn(color)
@@ -128,6 +138,16 @@ class BaseViewSpec : BaseTest() {
         val mockButton = Mockito.mock(ImageButton::class.java)
         view?.setCloseButton(mockButton)
         Mockito.verify(mockButton, mode).setImageResource(R.drawable.close_button_white)
+    }
+
+    private fun verifyCheckBox(color: String, expectedColor: Int) {
+        `when`(mockPayload.headerColor).thenReturn(color)
+        `when`(mockPayload.messageBodyColor).thenReturn(color)
+        `when`(mockPayload.backgroundColor).thenReturn(color)
+        `when`(mockDisplaySettings.optOut).thenReturn(true)
+
+        view?.populateViewData(mockMessage)
+        view?.findViewById<CheckBox>(R.id.opt_out_checkbox)?.textColors?.defaultColor shouldBeEqualTo expectedColor
     }
 
     @Test


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
