### PR TITLE
revert: chore: fix dependency check issue due to broken RetireJS analzer

### DIFF
--- a/dependency-check.gradle
+++ b/dependency-check.gradle
@@ -1,12 +1,6 @@
 allprojects {
     apply plugin: 'org.owasp.dependencycheck'
     dependencyCheck {
-        analyzers {
-            retirejs {
-                // Repository version locked due to https://github.com/jeremylong/DependencyCheck/issues/4695
-                retireJsUrl = 'https://raw.githubusercontent.com/RetireJS/retire.js/33b4076ce87f3898b81af4fc1770a7b65aa54bcb/repository/jsrepository.json'
-            }
-        }
         skipConfigurations += 'lintClassPath'
         skipProjects = [':test']
         // set the Common Vulnerability Scoring System value


### PR DESCRIPTION
# Description
This reverts commit c6879c5218d56e41bd28a08167b29ba6926d2562.
According to [this](https://github.com/jeremylong/DependencyCheck/issues/4695#issuecomment-1193634610), issue is fixed.
