### PR TITLE
chore: fix Test Reports add-on configuration for tests status display (SDKCF-5615)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -46,6 +46,10 @@ workflows:
         title: Run Tests
         inputs:
         - content: ./gradlew clean testRelease --tests com.rakuten.tech.mobile.inappmessaging.runtime.integration.IntegrationSpec
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
+        - is_enable_public_page: 'false'
     - custom-test-results-export@0:
         inputs:
         - test_name: Integration Tests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,7 +54,7 @@ workflows:
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
-        - is_enable_public_page: 'true'
+        - is_enable_public_page: 'false'
     # - slack@3:
     #     inputs:
     #     - channel: ''
@@ -202,10 +202,7 @@ workflows:
         - content: |-
             bundle install
             bundle exec danger --dangerfile=config/danger/Dangerfile
-    - deploy-to-bitrise-io@2:
-        inputs:
-        - deploy_path: "$SDK_PATH/build/test-results/"
-        - is_enable_public_page: 'true'
+    - deploy-to-bitrise-io@2: {}
     - cache-push@2:
         inputs:
         - cache_paths: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,31 +54,31 @@ workflows:
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
-        - is_enable_public_page: 'false'
-    - slack@3:
-        inputs:
-        - channel: ''
-        - webhook_url: "$SLACK_CHANNEL_WEBHOOK"
-        - text: ''
-        - title: ''
-        - author_name: ''
-        - channel_on_error: ''
-        - pretext: ''
-        - pretext_on_error: ''
-        - message_on_error: |+
-            $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Failure*
-            <$BITRISE_BUILD_URL|Open>
-        - message: |+
-            $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Success*
-            <$BITRISE_BUILD_URL|Open>
-        - fields: ''
-        - buttons: ''
-        - footer: ''
-        - footer_icon: ''
-        - timestamp: 'no'
-        - icon_url_on_error: ''
-        - from_username_on_error: ''
-        - color_on_error: "#d10b20"
+        - is_enable_public_page: 'true'
+    # - slack@3:
+    #     inputs:
+    #     - channel: ''
+    #     - webhook_url: "$SLACK_CHANNEL_WEBHOOK"
+    #     - text: ''
+    #     - title: ''
+    #     - author_name: ''
+    #     - channel_on_error: ''
+    #     - pretext: ''
+    #     - pretext_on_error: ''
+    #     - message_on_error: |+
+    #         $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Failure*
+    #         <$BITRISE_BUILD_URL|Open>
+    #     - message: |+
+    #         $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Success*
+    #         <$BITRISE_BUILD_URL|Open>
+    #     - fields: ''
+    #     - buttons: ''
+    #     - footer: ''
+    #     - footer_icon: ''
+    #     - timestamp: 'no'
+    #     - icon_url_on_error: ''
+    #     - from_username_on_error: ''
+    #     - color_on_error: "#d10b20"
   release:
     before_run:
     - _setup-env
@@ -104,10 +104,6 @@ workflows:
         - test_name: "${SDK_PATH}_release"
         - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
         - search_pattern: "*"
-    - deploy-to-bitrise-io@2:
-        inputs:
-        - deploy_path: "$SDK_PATH/build/outputs/aar"
-        - is_enable_public_page: 'false'
     - script@1:
         title: Retrieve Base64 PGP Key and save to file
         inputs:
@@ -206,7 +202,10 @@ workflows:
         - content: |-
             bundle install
             bundle exec danger --dangerfile=config/danger/Dangerfile
-    - deploy-to-bitrise-io@2: {}
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$SDK_PATH/build/test-results/"
+        - is_enable_public_page: 'true'
     - cache-push@2:
         inputs:
         - cache_paths: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -31,7 +31,7 @@ workflows:
         - content: "./gradlew detekt detektRelease lintAnalyzeDebug lintDebug lintReportDebug testDebugUnitTest jacocoDebugReport"
     - custom-test-results-export@0:
         inputs:
-        - test_name: Unit Tests (Debug)
+        - test_name: "${SDK_PATH}_debug"
         - base_path: "$SDK_PATH/build/test-results/testDebugUnitTest/"
         - search_pattern: "*"
   integration-test:
@@ -51,10 +51,6 @@ workflows:
         - test_name: Integration Tests
         - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
         - search_pattern: "*"
-    - deploy-to-bitrise-io@2:
-        inputs:
-        - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
-        - is_enable_public_page: 'false'
     - slack@3:
         inputs:
         - channel: ''
@@ -101,7 +97,7 @@ workflows:
         - content: "./gradlew currentVersion"
     - custom-test-results-export@0:
         inputs:
-        - test_name: Unit Tests (Release)
+        - test_name: "${SDK_PATH}_release"
         - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
         - search_pattern: "*"
     - deploy-to-bitrise-io@2:
@@ -206,6 +202,7 @@ workflows:
         - content: |-
             bundle install
             bundle exec danger --dangerfile=config/danger/Dangerfile
+    - deploy-to-bitrise-io@2: {}
     - cache-push@2:
         inputs:
         - cache_paths: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -55,30 +55,30 @@ workflows:
         inputs:
         - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
         - is_enable_public_page: 'false'
-    # - slack@3:
-    #     inputs:
-    #     - channel: ''
-    #     - webhook_url: "$SLACK_CHANNEL_WEBHOOK"
-    #     - text: ''
-    #     - title: ''
-    #     - author_name: ''
-    #     - channel_on_error: ''
-    #     - pretext: ''
-    #     - pretext_on_error: ''
-    #     - message_on_error: |+
-    #         $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Failure*
-    #         <$BITRISE_BUILD_URL|Open>
-    #     - message: |+
-    #         $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Success*
-    #         <$BITRISE_BUILD_URL|Open>
-    #     - fields: ''
-    #     - buttons: ''
-    #     - footer: ''
-    #     - footer_icon: ''
-    #     - timestamp: 'no'
-    #     - icon_url_on_error: ''
-    #     - from_username_on_error: ''
-    #     - color_on_error: "#d10b20"
+    - slack@3:
+        inputs:
+        - channel: ''
+        - webhook_url: "$SLACK_CHANNEL_WEBHOOK"
+        - text: ''
+        - title: ''
+        - author_name: ''
+        - channel_on_error: ''
+        - pretext: ''
+        - pretext_on_error: ''
+        - message_on_error: |+
+            $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Failure*
+            <$BITRISE_BUILD_URL|Open>
+        - message: |+
+            $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Success*
+            <$BITRISE_BUILD_URL|Open>
+        - fields: ''
+        - buttons: ''
+        - footer: ''
+        - footer_icon: ''
+        - timestamp: 'no'
+        - icon_url_on_error: ''
+        - from_username_on_error: ''
+        - color_on_error: "#d10b20"
   release:
     before_run:
     - _setup-env

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -46,15 +46,15 @@ workflows:
         title: Run Tests
         inputs:
         - content: ./gradlew clean testRelease --tests com.rakuten.tech.mobile.inappmessaging.runtime.integration.IntegrationSpec
-    - deploy-to-bitrise-io@2:
-        inputs:
-        - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
-        - is_enable_public_page: 'false'
     - custom-test-results-export@0:
         inputs:
         - test_name: Integration Tests
         - base_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
         - search_pattern: "*"
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$SDK_PATH/build/test-results/testReleaseUnitTest/"
+        - is_enable_public_page: 'false'
     - slack@3:
         inputs:
         - channel: ''

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -331,11 +331,6 @@ open class InAppMessagingSpec : BaseTest() {
         Mockito.verify(sessionManagerMock).onSessionUpdate()
     }
 
-    @Test
-    fun `should fail`() {
-        true.shouldBeFalse()
-    }
-
     private fun setupDisplayedView(message: Message) {
         val message2 = ValidTestMessage()
         CampaignRepository.instance().syncWith(listOf(message, message2), 0)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -331,11 +331,6 @@ open class InAppMessagingSpec : BaseTest() {
         Mockito.verify(sessionManagerMock).onSessionUpdate()
     }
 
-    @Test
-    fun `should fail`() {
-        false.shouldBeTrue()
-    }
-
     private fun setupDisplayedView(message: Message) {
         val message2 = ValidTestMessage()
         CampaignRepository.instance().syncWith(listOf(message, message2), 0)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -331,6 +331,11 @@ open class InAppMessagingSpec : BaseTest() {
         Mockito.verify(sessionManagerMock).onSessionUpdate()
     }
 
+    @Test
+    fun `should fail`() {
+        false.shouldBeTrue()
+    }
+
     private fun setupDisplayedView(message: Message) {
         val message2 = ValidTestMessage()
         CampaignRepository.instance().syncWith(listOf(message, message2), 0)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -331,6 +331,11 @@ open class InAppMessagingSpec : BaseTest() {
         Mockito.verify(sessionManagerMock).onSessionUpdate()
     }
 
+    @Test
+    fun `should fail`() {
+        true.shouldBeFalse()
+    }
+
     private fun setupDisplayedView(message: Message) {
         val message2 = ValidTestMessage()
         CampaignRepository.instance().syncWith(listOf(message, message2), 0)


### PR DESCRIPTION
# Description
Test Reports add-on should be used together with Deploy to Bitrise step in order to work.
Tests can be viewed inline via the PR's Checks tab, or via Bitrise' Test Reports tab.
Also, removed unnecessary step which is deploying AAR.

# Checklist
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [ ] I ran `./gradlew check` without errors
