### PR TITLE
inv: (not for merge) add accessibility checks in test app (SDKCF-5601)

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
+    androidTestImplementation "androidx.test:core-ktx:1.4.0"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -55,6 +55,13 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3'
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-accessibility:3.5.0-beta01'
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:3.14.7"
 }
 repositories {
     mavenCentral()

--- a/test/src/androidTest/java/com/rakuten/test/accessibility/FullScreenAccessibilityTest.kt
+++ b/test/src/androidTest/java/com/rakuten/test/accessibility/FullScreenAccessibilityTest.kt
@@ -1,0 +1,78 @@
+package com.rakuten.test.accessibility
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
+import com.rakuten.test.MainActivity
+import com.rakuten.test.helpers.Constants
+import com.rakuten.test.helpers.MockServerHelper
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.*
+import org.junit.runner.RunWith
+import com.rakuten.test.R as AppR
+import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
+
+@RunWith(AndroidJUnit4::class)
+class FullScreenAccessibilityTest {
+
+    /**
+     * Not properly working if running tests all at once probably due to MockWebServer setup.
+     * Need to manually execute each test separately.
+     *
+     */
+
+    @Rule
+    @JvmField
+    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun fullScreenTextOnly() {
+        MockServerHelper.doIamRequest(mockServer, "full-text-only.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    @Test
+    fun fullScreenImageOnly() {
+        MockServerHelper.doIamRequest(mockServer, "full-image-only.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    @Test
+    fun fullScreenTextImage() {
+        MockServerHelper.doIamRequest(mockServer, "full-text-image.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    companion object {
+        private val mockServer = MockWebServer()
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            mockServer.start(Constants.PORT)
+            mockServer.url(Constants.PATH)
+
+            AccessibilityChecks.enable()
+                .setRunChecksFromRootView(true)
+                .setThrowExceptionFor(AccessibilityCheckResult.AccessibilityCheckResultType.WARNING)
+        }
+
+        @AfterClass
+        fun afterClass() {
+            mockServer.shutdown()
+        }
+    }
+}

--- a/test/src/androidTest/java/com/rakuten/test/accessibility/FullScreenAccessibilityTest.kt
+++ b/test/src/androidTest/java/com/rakuten/test/accessibility/FullScreenAccessibilityTest.kt
@@ -1,78 +1,51 @@
 package com.rakuten.test.accessibility
 
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.accessibility.AccessibilityChecks
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
-import com.rakuten.test.MainActivity
 import com.rakuten.test.helpers.Constants
-import com.rakuten.test.helpers.MockServerHelper
+import com.rakuten.test.helpers.Utils
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.*
 import org.junit.runner.RunWith
-import com.rakuten.test.R as AppR
-import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
 
 @RunWith(AndroidJUnit4::class)
 class FullScreenAccessibilityTest {
+    private var mockServer = MockWebServer()
 
-    /**
-     * Not properly working if running tests all at once probably due to MockWebServer setup.
-     * Need to manually execute each test separately.
-     *
-     */
+    @Before
+    fun beforeTest() {
+        mockServer.start(Constants.PORT)
+        mockServer.url(Constants.PATH)
+    }
 
-    @Rule
-    @JvmField
-    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+    @After
+    fun afterTest() {
+        mockServer.shutdown()
+    }
 
     @Test
     fun fullScreenTextOnly() {
-        MockServerHelper.doIamRequest(mockServer, "full-text-only.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer,"full-text-only.json")
     }
 
     @Test
     fun fullScreenImageOnly() {
-        MockServerHelper.doIamRequest(mockServer, "full-image-only.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer,"full-image-only.json", 3000)
     }
 
     @Test
     fun fullScreenTextImage() {
-        MockServerHelper.doIamRequest(mockServer, "full-text-image.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer,"full-text-image.json")
     }
 
     companion object {
-        private val mockServer = MockWebServer()
-
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            mockServer.start(Constants.PORT)
-            mockServer.url(Constants.PATH)
-
             AccessibilityChecks.enable()
                 .setRunChecksFromRootView(true)
                 .setThrowExceptionFor(AccessibilityCheckResult.AccessibilityCheckResultType.WARNING)
-        }
-
-        @AfterClass
-        fun afterClass() {
-            mockServer.shutdown()
         }
     }
 }

--- a/test/src/androidTest/java/com/rakuten/test/accessibility/ModalAccessibilityTest.kt
+++ b/test/src/androidTest/java/com/rakuten/test/accessibility/ModalAccessibilityTest.kt
@@ -1,0 +1,78 @@
+package com.rakuten.test.accessibility
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
+import com.rakuten.test.MainActivity
+import com.rakuten.test.helpers.Constants
+import com.rakuten.test.helpers.MockServerHelper
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.*
+import org.junit.runner.RunWith
+import com.rakuten.test.R as AppR
+import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
+
+@RunWith(AndroidJUnit4::class)
+class ModalAccessibilityTest {
+
+    /**
+     * Not properly working if running tests all at once probably due to MockWebServer setup.
+     * Need to manually execute each test separately.
+     *
+     */
+
+    @Rule
+    @JvmField
+    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun modalTextOnly() {
+        MockServerHelper.doIamRequest(mockServer, "modal-text-only.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    @Test
+    fun modalImageOnly() {
+        MockServerHelper.doIamRequest(mockServer, "modal-image-only.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    @Test
+    fun modalTextImage() {
+        MockServerHelper.doIamRequest(mockServer, "modal-text-image.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    companion object {
+        private val mockServer = MockWebServer()
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            mockServer.start(Constants.PORT)
+            mockServer.url(Constants.PATH)
+
+            AccessibilityChecks.enable()
+                .setRunChecksFromRootView(true)
+                .setThrowExceptionFor(AccessibilityCheckResult.AccessibilityCheckResultType.WARNING)
+        }
+
+        @AfterClass
+        fun afterClass() {
+            mockServer.shutdown()
+        }
+    }
+}

--- a/test/src/androidTest/java/com/rakuten/test/accessibility/ModalAccessibilityTest.kt
+++ b/test/src/androidTest/java/com/rakuten/test/accessibility/ModalAccessibilityTest.kt
@@ -1,78 +1,51 @@
 package com.rakuten.test.accessibility
 
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.accessibility.AccessibilityChecks
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
-import com.rakuten.test.MainActivity
+import com.rakuten.test.helpers.Utils
 import com.rakuten.test.helpers.Constants
-import com.rakuten.test.helpers.MockServerHelper
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.*
 import org.junit.runner.RunWith
-import com.rakuten.test.R as AppR
-import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
 
 @RunWith(AndroidJUnit4::class)
 class ModalAccessibilityTest {
+    private var mockServer = MockWebServer()
 
-    /**
-     * Not properly working if running tests all at once probably due to MockWebServer setup.
-     * Need to manually execute each test separately.
-     *
-     */
+    @Before
+    fun beforeTest() {
+        mockServer.start(Constants.PORT)
+        mockServer.url(Constants.PATH)
+    }
 
-    @Rule
-    @JvmField
-    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+    @After
+    fun afterTest() {
+        mockServer.shutdown()
+    }
 
     @Test
     fun modalTextOnly() {
-        MockServerHelper.doIamRequest(mockServer, "modal-text-only.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer, "modal-text-only.json")
     }
 
     @Test
     fun modalImageOnly() {
-        MockServerHelper.doIamRequest(mockServer, "modal-image-only.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer,"modal-image-only.json", 3000)
     }
 
     @Test
     fun modalTextImage() {
-        MockServerHelper.doIamRequest(mockServer, "modal-text-image.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer,"modal-text-image.json", 3000)
     }
 
     companion object {
-        private val mockServer = MockWebServer()
-
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            mockServer.start(Constants.PORT)
-            mockServer.url(Constants.PATH)
-
             AccessibilityChecks.enable()
                 .setRunChecksFromRootView(true)
                 .setThrowExceptionFor(AccessibilityCheckResult.AccessibilityCheckResultType.WARNING)
-        }
-
-        @AfterClass
-        fun afterClass() {
-            mockServer.shutdown()
         }
     }
 }

--- a/test/src/androidTest/java/com/rakuten/test/accessibility/SlideUpAccessibilityTest.kt
+++ b/test/src/androidTest/java/com/rakuten/test/accessibility/SlideUpAccessibilityTest.kt
@@ -1,60 +1,41 @@
 package com.rakuten.test.accessibility
 
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.accessibility.AccessibilityChecks
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
-import com.rakuten.test.MainActivity
 import com.rakuten.test.helpers.Constants
-import com.rakuten.test.helpers.MockServerHelper
+import com.rakuten.test.helpers.Utils
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.*
 import org.junit.runner.RunWith
-import com.rakuten.test.R as AppR
-import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
 
 @RunWith(AndroidJUnit4::class)
 class SlideUpAccessibilityTest {
+    private var mockServer = MockWebServer()
 
-    /**
-     * Not properly working if running tests all at once probably due to MockWebServer setup.
-     * Need to manually execute each test separately.
-     *
-     */
+    @Before
+    fun beforeTest() {
+        mockServer.start(Constants.PORT)
+        mockServer.url(Constants.PATH)
+    }
 
-    @Rule
-    @JvmField
-    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+    @After
+    fun afterTest() {
+        mockServer.shutdown()
+    }
 
     @Test
     fun slideUpClose() {
-        MockServerHelper.doIamRequest(mockServer, "slide-up-close.json")
-
-        onView(withId(AppR.id.login_successful)).perform(click())
-        Thread.sleep(1000)
-        onView(withId(IamR.id.message_close_button)).perform(click())
+        Utils.performNormalFlow(mockServer,"slide-up-close.json")
     }
 
     companion object {
-        private val mockServer = MockWebServer()
-
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            mockServer.start(Constants.PORT)
-            mockServer.url(Constants.PATH)
-
             AccessibilityChecks.enable()
                 .setRunChecksFromRootView(true)
                 .setThrowExceptionFor(AccessibilityCheckResult.AccessibilityCheckResultType.WARNING)
-        }
-
-        @AfterClass
-        fun afterClass() {
-            mockServer.shutdown()
         }
     }
 }

--- a/test/src/androidTest/java/com/rakuten/test/accessibility/SlideUpAccessibilityTest.kt
+++ b/test/src/androidTest/java/com/rakuten/test/accessibility/SlideUpAccessibilityTest.kt
@@ -1,0 +1,60 @@
+package com.rakuten.test.accessibility
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
+import com.rakuten.test.MainActivity
+import com.rakuten.test.helpers.Constants
+import com.rakuten.test.helpers.MockServerHelper
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.*
+import org.junit.runner.RunWith
+import com.rakuten.test.R as AppR
+import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
+
+@RunWith(AndroidJUnit4::class)
+class SlideUpAccessibilityTest {
+
+    /**
+     * Not properly working if running tests all at once probably due to MockWebServer setup.
+     * Need to manually execute each test separately.
+     *
+     */
+
+    @Rule
+    @JvmField
+    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun slideUpClose() {
+        MockServerHelper.doIamRequest(mockServer, "slide-up-close.json")
+
+        onView(withId(AppR.id.login_successful)).perform(click())
+        Thread.sleep(1000)
+        onView(withId(IamR.id.message_close_button)).perform(click())
+    }
+
+    companion object {
+        private val mockServer = MockWebServer()
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            mockServer.start(Constants.PORT)
+            mockServer.url(Constants.PATH)
+
+            AccessibilityChecks.enable()
+                .setRunChecksFromRootView(true)
+                .setThrowExceptionFor(AccessibilityCheckResult.AccessibilityCheckResultType.WARNING)
+        }
+
+        @AfterClass
+        fun afterClass() {
+            mockServer.shutdown()
+        }
+    }
+}

--- a/test/src/androidTest/java/com/rakuten/test/helpers/Constants.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/Constants.kt
@@ -3,5 +3,6 @@ package com.rakuten.test.helpers
 object Constants {
     const val PORT = 6789
     const val PATH = "iam/"
+    const val CONFIG_URL = "http://127.0.0.1:$PORT/${PATH}config/"
     const val RESP_STUB_DIR = "response-stubs"
 }

--- a/test/src/androidTest/java/com/rakuten/test/helpers/Constants.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/Constants.kt
@@ -1,0 +1,7 @@
+package com.rakuten.test.helpers
+
+object Constants {
+    const val PORT = 6789
+    const val PATH = "iam/"
+    const val RESP_STUB_DIR = "response-stubs"
+}

--- a/test/src/androidTest/java/com/rakuten/test/helpers/JsonFileReader.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/JsonFileReader.kt
@@ -1,0 +1,13 @@
+package com.rakuten.test.helpers
+
+import java.io.InputStreamReader
+
+class JsonFileReader(path: String) {
+    val content: String
+
+    init {
+        val reader = InputStreamReader(this.javaClass.classLoader!!.getResourceAsStream(path))
+        content = reader.readText()
+        reader.close()
+    }
+}

--- a/test/src/androidTest/java/com/rakuten/test/helpers/MockServerHelper.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/MockServerHelper.kt
@@ -11,7 +11,6 @@ object MockServerHelper {
 
         @Throws(InterruptedException::class)
         override fun dispatch(request: RecordedRequest): MockResponse {
-            System.out.println("[Mau]: ${request.path}")
             with(request.path) {
                 when {
                     contains("/config") ->

--- a/test/src/androidTest/java/com/rakuten/test/helpers/MockServerHelper.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/MockServerHelper.kt
@@ -1,18 +1,34 @@
 package com.rakuten.test.helpers
 
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 
 object MockServerHelper {
+    var pingJsonFilename = ""
 
-    fun doIamRequest(server: MockWebServer, jsonFilename: String) {
-        server.enqueue(MockResponse()
-            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/config.json").content))
-        server.enqueue(MockResponse()
-            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/$jsonFilename").content))
-        server.enqueue(MockResponse()
-            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/display-permission.json").content))
+    val dispatcher: Dispatcher = object : Dispatcher() {
 
-        Thread.sleep(1000)
+        @Throws(InterruptedException::class)
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            System.out.println("[Mau]: ${request.path}")
+            with(request.path) {
+                when {
+                    contains("/config") ->
+                        return MockResponse()
+                            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/config.json").content)
+                    contains("/ping") ->
+                        return MockResponse()
+                            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/$pingJsonFilename").content)
+                    contains("/display_permission") ->
+                        return MockResponse()
+                            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/display-permission.json").content)
+                    contains("/impression") ->
+                        return MockResponse().setResponseCode(200)
+                    else ->
+                        return MockResponse().setResponseCode(500)
+                }
+            }
+        }
     }
 }

--- a/test/src/androidTest/java/com/rakuten/test/helpers/MockServerHelper.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/MockServerHelper.kt
@@ -1,0 +1,18 @@
+package com.rakuten.test.helpers
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+
+object MockServerHelper {
+
+    fun doIamRequest(server: MockWebServer, jsonFilename: String) {
+        server.enqueue(MockResponse()
+            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/config.json").content))
+        server.enqueue(MockResponse()
+            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/$jsonFilename").content))
+        server.enqueue(MockResponse()
+            .setBody(JsonFileReader("${Constants.RESP_STUB_DIR}/display-permission.json").content))
+
+        Thread.sleep(1000)
+    }
+}

--- a/test/src/androidTest/java/com/rakuten/test/helpers/Utils.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/Utils.kt
@@ -1,8 +1,9 @@
 package com.rakuten.test.helpers
 
 import androidx.test.core.app.launchActivity
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.matcher.ViewMatchers
 import com.rakuten.test.MainActivity
 import com.rakuten.test.R
@@ -17,14 +18,14 @@ object Utils {
 
         // Workaround to trigger `configure` for every test
         // because launchActivity and close does not seem to kill app not triggering ping.
-        Espresso.onView(ViewMatchers.withId(R.id.reconfigure)).perform(ViewActions.click())
-        Espresso.onView(ViewMatchers.withId(R.id.edit_config_url)).perform(ViewActions.replaceText(Constants.CONFIG_URL))
-        Espresso.onView(ViewMatchers.withText(android.R.string.ok)).perform(ViewActions.click())
+        onView(ViewMatchers.withId(R.id.reconfigure)).perform(click())
+        onView(ViewMatchers.withId(R.id.edit_config_url)).perform(replaceText(Constants.CONFIG_URL))
+        onView(ViewMatchers.withText(android.R.string.ok)).perform(click())
 
-        Espresso.onView(ViewMatchers.withId(R.id.login_successful)).perform(ViewActions.click())
+        onView(ViewMatchers.withId(R.id.login_successful)).perform(click())
         Thread.sleep(sleep)
-        Espresso.onView(ViewMatchers.withId(com.rakuten.tech.mobile.inappmessaging.runtime.R.id.message_close_button))
-            .perform(ViewActions.click())
+        onView(ViewMatchers.withId(com.rakuten.tech.mobile.inappmessaging.runtime.R.id.message_close_button))
+            .perform(click())
 
         scenario.close()
     }

--- a/test/src/androidTest/java/com/rakuten/test/helpers/Utils.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/Utils.kt
@@ -6,7 +6,8 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.matcher.ViewMatchers
 import com.rakuten.test.MainActivity
-import com.rakuten.test.R
+import com.rakuten.test.R as AppR
+import com.rakuten.tech.mobile.inappmessaging.runtime.R as IamR
 import okhttp3.mockwebserver.MockWebServer
 
 object Utils {
@@ -18,14 +19,17 @@ object Utils {
 
         // Workaround to trigger `configure` for every test
         // because launchActivity and close does not seem to kill app not triggering ping.
-        onView(ViewMatchers.withId(R.id.reconfigure)).perform(click())
-        onView(ViewMatchers.withId(R.id.edit_config_url)).perform(replaceText(Constants.CONFIG_URL))
+        onView(ViewMatchers.withId(AppR.id.reconfigure)).perform(click())
+        onView(ViewMatchers.withId(AppR.id.edit_config_url)).perform(replaceText(Constants.CONFIG_URL))
         onView(ViewMatchers.withText(android.R.string.ok)).perform(click())
 
-        onView(ViewMatchers.withId(R.id.login_successful)).perform(click())
+        onView(ViewMatchers.withId(AppR.id.login_successful)).perform(click())
+
+        // Provide some time while processing campaigns esp. those with images.
+        // There must be a better way to do this.
         Thread.sleep(sleep)
-        onView(ViewMatchers.withId(com.rakuten.tech.mobile.inappmessaging.runtime.R.id.message_close_button))
-            .perform(click())
+
+        onView(ViewMatchers.withId(IamR.id.message_close_button)).perform(click())
 
         scenario.close()
     }

--- a/test/src/androidTest/java/com/rakuten/test/helpers/Utils.kt
+++ b/test/src/androidTest/java/com/rakuten/test/helpers/Utils.kt
@@ -1,0 +1,31 @@
+package com.rakuten.test.helpers
+
+import androidx.test.core.app.launchActivity
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import com.rakuten.test.MainActivity
+import com.rakuten.test.R
+import okhttp3.mockwebserver.MockWebServer
+
+object Utils {
+    fun performNormalFlow(mockServer: MockWebServer, jsonFileName: String, sleep: Long = 1000) {
+        MockServerHelper.pingJsonFilename = jsonFileName
+        mockServer.dispatcher = MockServerHelper.dispatcher
+
+        val scenario = launchActivity<MainActivity>()
+
+        // Workaround to trigger `configure` for every test
+        // because launchActivity and close does not seem to kill app not triggering ping.
+        Espresso.onView(ViewMatchers.withId(R.id.reconfigure)).perform(ViewActions.click())
+        Espresso.onView(ViewMatchers.withId(R.id.edit_config_url)).perform(ViewActions.replaceText(Constants.CONFIG_URL))
+        Espresso.onView(ViewMatchers.withText(android.R.string.ok)).perform(ViewActions.click())
+
+        Espresso.onView(ViewMatchers.withId(R.id.login_successful)).perform(ViewActions.click())
+        Thread.sleep(sleep)
+        Espresso.onView(ViewMatchers.withId(com.rakuten.tech.mobile.inappmessaging.runtime.R.id.message_close_button))
+            .perform(ViewActions.click())
+
+        scenario.close()
+    }
+}

--- a/test/src/androidTest/resources/response-stubs/config.json
+++ b/test/src/androidTest/resources/response-stubs/config.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "rolloutPercentage": 100,
+    "endpoints": {
+      "ping": "http://localhost:6789/ping",
+      "impression": "http://localhost:6789/impression",
+      "displayPermission": "http://localhost:6789/display_permission"
+    }
+  }
+}

--- a/test/src/androidTest/resources/response-stubs/config.json
+++ b/test/src/androidTest/resources/response-stubs/config.json
@@ -2,9 +2,9 @@
   "data": {
     "rolloutPercentage": 100,
     "endpoints": {
-      "ping": "http://localhost:6789/ping",
-      "impression": "http://localhost:6789/impression",
-      "displayPermission": "http://localhost:6789/display_permission"
+      "ping": "http://127.0.0.1:6789/ping",
+      "impression": "http://127.0.0.1:6789/impression",
+      "displayPermission": "http://127.0.0.1:6789/display_permission"
     }
   }
 }

--- a/test/src/androidTest/resources/response-stubs/display-permission.json
+++ b/test/src/androidTest/resources/response-stubs/display-permission.json
@@ -1,0 +1,4 @@
+{
+  "display": true,
+  "performPing": false
+}

--- a/test/src/androidTest/resources/response-stubs/full-image-only.json
+++ b/test/src/androidTest/resources/response-stubs/full-image-only.json
@@ -1,0 +1,53 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "full-image-only",
+        "maxImpressions": 999,
+        "type": 2,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "",
+          "header": "",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "imageUrl": "https://cdn.pixabay.com/photo/2014/06/03/19/38/board-361516_1280.jpg",
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": false,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "buttons": []
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/androidTest/resources/response-stubs/full-text-image.json
+++ b/test/src/androidTest/resources/response-stubs/full-text-image.json
@@ -1,0 +1,53 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "full-text-image",
+        "maxImpressions": 999,
+        "type": 2,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "test",
+          "header": "Test Campaign",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "imageUrl": "https://cdn.pixabay.com/photo/2014/06/03/19/38/board-361516_1280.jpg",
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": false,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "buttons": []
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/androidTest/resources/response-stubs/full-text-only.json
+++ b/test/src/androidTest/resources/response-stubs/full-text-only.json
@@ -1,0 +1,52 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "full-text-only",
+        "maxImpressions": 999,
+        "type": 2,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "test",
+          "header": "Test Campaign",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": false,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "buttons": []
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/androidTest/resources/response-stubs/modal-image-only.json
+++ b/test/src/androidTest/resources/response-stubs/modal-image-only.json
@@ -1,0 +1,53 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "modal-image-only",
+        "maxImpressions": 999,
+        "type": 1,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "",
+          "header": "",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "imageUrl": "https://cdn.pixabay.com/photo/2014/06/03/19/38/board-361516_1280.jpg",
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": false,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "buttons": []
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/androidTest/resources/response-stubs/modal-text-image.json
+++ b/test/src/androidTest/resources/response-stubs/modal-text-image.json
@@ -1,0 +1,53 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "modal-text-image",
+        "maxImpressions": 999,
+        "type": 1,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "test",
+          "header": "Test Campaign",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "imageUrl": "https://cdn.pixabay.com/photo/2014/06/03/19/38/board-361516_1280.jpg",
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": false,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "buttons": []
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/androidTest/resources/response-stubs/modal-text-only.json
+++ b/test/src/androidTest/resources/response-stubs/modal-text-only.json
@@ -1,0 +1,59 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "modal-text-only",
+        "maxImpressions": 999,
+        "type": 1,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "test",
+          "header": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": false,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "buttons": [{
+                "buttonText": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "buttonTextColor": "#1d1d1d",
+                "buttonBackgroundColor": "#ffffff",
+                "buttonBehavior": {
+                  "action": 3
+                }
+              }]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/androidTest/resources/response-stubs/slide-up-close.json
+++ b/test/src/androidTest/resources/response-stubs/slide-up-close.json
@@ -1,0 +1,58 @@
+{
+  "currentPingMillis": 0,
+  "nextPingMillis": 3600000,
+  "data": [
+    {
+      "campaignData": {
+        "campaignId": "slide-up-close",
+        "maxImpressions": 999,
+        "type": 3,
+        "isTest": false,
+        "isCampaignDismissable": true,
+        "hasNoEndDate": false,
+        "infiniteImpressions": true,
+        "triggers": [
+          {
+            "type": 1,
+            "eventType": 2,
+            "eventName": "Login Successful Event",
+            "attributes": []
+          }
+        ],
+        "messagePayload": {
+          "title": "test",
+          "messageBody": "test",
+          "header": "Test Campaign",
+          "titleColor": "#000000",
+          "headerColor": "#000000",
+          "messageBodyColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "frameColor": "#ffffff",
+          "resource": {
+            "cropType": 2
+          },
+          "messageSettings": {
+            "displaySettings": {
+              "slideFrom": 1,
+              "endTimeMillis": 9999999999999,
+              "orientation": 1,
+              "textAlign": 2,
+              "optOut": true,
+              "delay": 0,
+              "html": false
+            },
+            "controlSettings": {
+              "content": {
+                "onClickBehavior": {
+                  "action": 3,
+                  "uri": null
+                }
+              },
+              "buttons": []
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/src/main/AndroidManifest.xml
+++ b/test/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
-    android:networkSecurityConfig="@xml/network_security_config"
+    android:usesCleartextTraffic="true"
     android:theme="@style/AppTheme">
     <activity
       android:name=".MainActivity"

--- a/test/src/main/java/com/rakuten/test/MainApplication.kt
+++ b/test/src/main/java/com/rakuten/test/MainApplication.kt
@@ -11,7 +11,8 @@ class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         settings = IAMSettings(this)
-        InAppMessaging.configure(this)
+//        InAppMessaging.configure(this)
+        InAppMessaging.configure(this, configUrl = "http://127.0.0.1:6789/iam/")
         InAppMessaging.instance().registerPreference(provider)
     }
 }

--- a/test/src/main/java/com/rakuten/test/MainApplication.kt
+++ b/test/src/main/java/com/rakuten/test/MainApplication.kt
@@ -11,8 +11,7 @@ class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         settings = IAMSettings(this)
-//        InAppMessaging.configure(this)
-        InAppMessaging.configure(this, configUrl = "http://127.0.0.1:6789/iam/")
+        InAppMessaging.configure(this)
         InAppMessaging.instance().registerPreference(provider)
     }
 }


### PR DESCRIPTION
To automate accessibility checks, we need to do UI tests using Espresso (support was discontinued in Robolectric).
https://developer.android.com/guide/topics/ui/accessibility/testing#automated

Here I added simple UI flows using the `test` module (test app) because we need an Application/Activity for UI tests.

It would be nice to do these tests in the `inappmessaging` module directly (if possible), or run UI tests in CI.
