### PR TITLE
improve: fix close button's content label accessibility warnings (SDKCF-5601)

### DIFF
--- a/inappmessaging/src/main/res/values-ja/strings.xml
+++ b/inappmessaging/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="in_app_message_image">クローズボタン</string>
-  <string name="close_button">アプリ内メッセージングのイメージ</string>
+  <string name="in_app_message_image">アプリ内メッセージングのイメージ</string>
+  <string name="close_button">メッセージを閉じる</string>
   <string name="message_opt_out_text">次回から表示しない</string>
 </resources>

--- a/inappmessaging/src/main/res/values/strings.xml
+++ b/inappmessaging/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
   <!-- UI components text -->
   <string name="in_app_message_image">in-app message image</string>
-  <string name="close_button">close button</string>
+  <string name="close_button">close message</string>
   <string name="message_opt_out_text">Do not show me this message again</string>
 </resources>


### PR DESCRIPTION
# Description
Fixes the warning:
`This item's android:contentDescription, "close button" contains the item type button`
Also corrected the Japanese translation.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
