### PR TITLE
fix: AppStart-only campaigns are re-displayed when switching users (SDKCF-6010)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -483,6 +483,7 @@ Documents targeting Product Managers:
 * SDKCF-6035: Added `closeTooltip()` API to manually close displayed tooltip by `viewId` (`UIElement` identifier).
 * SDKCF-6009: Fixed issue on campaign not displayed after going to background.
 * SDKCF-6025: Added Push Primer opt-in tracking for Android 13 and up devices. Please see [usage](#push-primer-tracker) section for details.
+* SDKCF-6010: Fixed re-display of AppStart-only campaigns when switching users, and to align with iOS.
 
 ### 7.2.0 (2022-09-28)
 * SDKCF-5038: Refactored event logging logic and campaign repository to align with iOS.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtil.kt
@@ -128,7 +128,6 @@ internal abstract class EventMatchingUtil {
 
         override fun clearNonPersistentEvents() {
             matchedEvents.clear()
-            triggeredPersistentCampaigns.clear()
         }
 
         private fun isEventMatchingOneOfTriggers(event: Event, triggers: List<Trigger>) =

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -237,6 +237,23 @@ class InAppMessagingBasicSpec : InAppMessagingSpec() {
         verify(sessMock).onSessionUpdate()
     }
 
+    @Test
+    fun `should not clear persistent campaigns list when changing user`() {
+        EventMatchingUtil.instance().matchedEvents.clear()
+        EventMatchingUtil.instance().matchedEvents["app-start-campaign"] = mutableListOf(AppStartEvent())
+        EventMatchingUtil.instance().matchedEvents["dummy-campaign"] =
+            mutableListOf(AppStartEvent(), LoginSuccessfulEvent())
+
+        EventMatchingUtil.instance().triggeredPersistentCampaigns.clear()
+        EventMatchingUtil.instance().triggeredPersistentCampaigns.add("app-start-campaign")
+
+        // Simulate change user
+        SessionManager.onSessionUpdate()
+
+        EventMatchingUtil.instance().matchedEvents.shouldBeEmpty() // cleared
+        EventMatchingUtil.instance().triggeredPersistentCampaigns.shouldHaveSize(1) // not cleared
+    }
+
     companion object {
         private const val EXCEPTION_MSG = "should not throw exception"
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtilSpec.kt
@@ -249,4 +249,14 @@ class EventMatchingUtilClearSpec : EventMatchingUtilSpec() {
         eventMatchingUtil.clearNonPersistentEvents()
         eventMatchingUtil.matchedEvents(mockCampaign).shouldNotBeEmpty()
     }
+
+    @Test
+    fun `should not clear triggered persistent campaigns list`() {
+        eventMatchingUtil.triggeredPersistentCampaigns.clear()
+        eventMatchingUtil.triggeredPersistentCampaigns.add("app-start-campaign")
+
+        eventMatchingUtil.clearNonPersistentEvents()
+
+        eventMatchingUtil.triggeredPersistentCampaigns.shouldHaveSize(1)
+    }
 }


### PR DESCRIPTION
# Description
When switching users, persistent campaigns list is getting cleared to show campaign for other user. 
This handling will be removed, thus making the campaign show only once throughout the app session regardless of user status.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
