### PR TITLE
fix: fix campaign is sometimes not displayed on app launch (SDKCF-6267)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -483,8 +483,9 @@ Documents targeting Product Managers:
 
 ## <a name="changelog"></a> Changelog
 
-### 7.4.0 (In-Progress)
+### 7.3.1 (In-Progress)
 * SDKCF-6126: Fixed incorrect tooltip position on scroll views and during device screen rotation.
+* SDKCF-6267: Fixed issue where campaign is sometimes not displayed on app launch.
 
 ### 7.3.0 (2022-12-13)
 * SDKCF-5835: Updated dependencies to remove vulnerabilities.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -114,8 +114,10 @@ internal class InApp(
             val isSameUser = !accountRepo.updateUserInfo()
             val areCampaignsSynced = campaignRepo.lastSyncMillis != null && eventMatchingUtil.eventBuffer.isEmpty()
 
-            InAppLogger(TAG).debug("${event.getEventName()}, isConfigEnabled: $isConfigEnabled, " +
-                    "isSameUser: $isSameUser, areCampaignsSynced: $areCampaignsSynced")
+            InAppLogger(TAG).debug(
+                "${event.getEventName()}, isConfigEnabled: $isConfigEnabled, " +
+                    "isSameUser: $isSameUser, areCampaignsSynced: $areCampaignsSynced"
+            )
 
             if (!isConfigEnabled || !isSameUser || !areCampaignsSynced) {
                 // To be processed later (flushed after sync)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -76,12 +76,6 @@ abstract class InAppMessaging internal constructor() {
     internal abstract fun isLocalCachingEnabled(): Boolean
 
     /**
-     * This method moves temp data to persistent cache.
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
-    internal abstract fun flushEventList()
-
-    /**
      * Close the currently displayed message.
      * This should be called when app needs to force-close the displayed message without user action.
      * Calling this method will not increment the campaign impression.
@@ -228,7 +222,5 @@ abstract class InAppMessaging internal constructor() {
         override fun closeTooltip(viewId: String) = Unit
 
         override fun trackPushPrimer(permissions: Array<String>, grantResults: IntArray) = Unit
-
-        override fun flushEventList() = Unit
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtil.kt
@@ -8,7 +8,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigge
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.matchingEventName
 
 internal abstract class EventMatchingUtil {
-    internal val tempEvents = arrayListOf<Event>()
+    internal val eventBuffer = arrayListOf<Event>()
     internal val persistentEvents = mutableSetOf<Event>()
     internal val matchedEvents = mutableMapOf<String, MutableList<Event>>()
     internal val triggeredPersistentCampaigns = mutableSetOf<String>()
@@ -136,16 +136,16 @@ internal abstract class EventMatchingUtil {
         }
 
         override fun addToEventBuffer(event: Event) {
-            synchronized(tempEvents) {
-                tempEvents.add(event)
-                InAppLogger(TAG).debug("Buffer: " + tempEvents.map { it.getEventName() })
+            synchronized(eventBuffer) {
+                eventBuffer.add(event)
+                InAppLogger(TAG).debug("Buffer: " + eventBuffer.map { it.getEventName() })
             }
         }
 
         override fun flushEventBuffer() {
-            synchronized(tempEvents) {
-                tempEvents.forEach { ev -> matchAndStore(ev) }
-                tempEvents.clear()
+            synchronized(eventBuffer) {
+                eventBuffer.forEach { ev -> matchAndStore(ev) }
+                eventBuffer.clear()
                 InAppLogger(TAG).debug("Buffer: []")
             }
         }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtil.kt
@@ -8,6 +8,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigge
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.matchingEventName
 
 internal abstract class EventMatchingUtil {
+    internal val tempEvents = arrayListOf<Event>()
     internal val persistentEvents = mutableSetOf<Event>()
     internal val matchedEvents = mutableMapOf<String, MutableList<Event>>()
     internal val triggeredPersistentCampaigns = mutableSetOf<String>()
@@ -32,6 +33,10 @@ internal abstract class EventMatchingUtil {
     abstract fun removeSetOfMatchedEvents(eventsToRemove: Set<Event>, campaign: Message): Boolean
 
     abstract fun clearNonPersistentEvents()
+
+    abstract fun addToEventBuffer(event: Event)
+
+    abstract fun flushEventBuffer()
 
     companion object {
         private const val TAG = "IAM_EventMatchingUtil"
@@ -128,6 +133,21 @@ internal abstract class EventMatchingUtil {
 
         override fun clearNonPersistentEvents() {
             matchedEvents.clear()
+        }
+
+        override fun addToEventBuffer(event: Event) {
+            synchronized(tempEvents) {
+                tempEvents.add(event)
+                InAppLogger(TAG).debug("Buffer: " + tempEvents.map { it.getEventName() })
+            }
+        }
+
+        override fun flushEventBuffer() {
+            synchronized(tempEvents) {
+                tempEvents.forEach { ev -> matchAndStore(ev) }
+                tempEvents.clear()
+                InAppLogger(TAG).debug("Buffer: []")
+            }
         }
 
         private fun isEventMatchingOneOfTriggers(event: Event, triggers: List<Trigger>) =

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.api.MessageMixerRetrofitService
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.CampaignType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
@@ -19,6 +18,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RetryDelayUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RuntimeUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.WorkerUtils
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.EventMatchingUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.EventMessageReconciliationScheduler
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.MessageMixerPingScheduler
 import retrofit2.Call
@@ -137,7 +137,7 @@ internal class MessageMixerWorker(
         )
 
         // Match&Store any temp events using lately synced campaigns.
-        InAppMessaging.instance().flushEventList()
+        EventMatchingUtil.instance().flushEventBuffer()
 
         // Start a new MessageEventReconciliationWorker, there was a new Ping Response to parse.
         // This worker will attempt to cancel message scheduled but hasn't been displayed yet

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -12,9 +12,7 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import com.nhaarman.mockitokotlin2.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.InAppMessageType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.Tooltip
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.AppStartEvent
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.LoginSuccessfulEvent
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.PurchaseSuccessfulEvent
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.messages.ValidTestMessage
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.*
@@ -84,7 +82,11 @@ open class InAppMessagingSpec : BaseTest() {
     internal fun initializeMockInstance(
         rollout: Int = 100,
         displayManager: DisplayManager = this.displayManager,
+        eventsManager: EventsManager = EventsManager,
+        eventMatchingUtil: EventMatchingUtil = EventMatchingUtil.instance(),
         accountRepo: AccountRepository = AccountRepository.instance(),
+        campaignRepo: CampaignRepository = CampaignRepository.instance(),
+        configRepo: ConfigResponseRepository = ConfigResponseRepository.instance(),
         sessionManager: SessionManager = SessionManager,
         readinessManager: MessageReadinessManager = MessageReadinessManager.instance(),
         primerManager: PushPrimerTrackerManager = PushPrimerTrackerManager
@@ -97,7 +99,10 @@ open class InAppMessagingSpec : BaseTest() {
             isDebugLogging = false,
             displayManager = displayManager,
             eventsManager = eventsManager,
+            eventMatchingUtil = eventMatchingUtil,
             accountRepo = accountRepo,
+            campaignRepo = campaignRepo,
+            configRepo = configRepo,
             sessionManager = sessionManager,
             messageReadinessManager = readinessManager,
             primerManager = primerManager
@@ -126,16 +131,6 @@ class InAppMessagingBasicSpec : InAppMessagingSpec() {
         InAppMessaging.instance().getRegisteredActivity() shouldBeEqualTo activity
         InAppMessaging.instance().unregisterMessageDisplayActivity()
         InAppMessaging.instance().getRegisteredActivity().shouldBeNull()
-    }
-
-    @SuppressWarnings("SwallowedException")
-    @Test
-    fun `should not crash logging event for initialized instance`() {
-        initializeInstance()
-
-        try {
-            InAppMessaging.instance().logEvent(AppStartEvent())
-        } catch (e: Exception) { Assert.fail(EXCEPTION_MSG) }
     }
 
     @SuppressWarnings("SwallowedException")
@@ -174,67 +169,10 @@ class InAppMessagingBasicSpec : InAppMessagingSpec() {
     }
 
     @Test
-    fun `should not log event if config is false`() {
-        val instance = initializeMockInstance(0)
-
-        instance.logEvent(AppStartEvent())
-        instance.logEvent(AppStartEvent())
-        instance.logEvent(PurchaseSuccessfulEvent())
-        instance.logEvent(LoginSuccessfulEvent())
-        Mockito.verify(eventsManager, never()).onEventReceived(any(), any(), any())
-    }
-
-    @Test
-    fun `should move temp data to repo`() {
-        val instance = initializeMockInstance(0)
-        instance.registerPreference(TestUserInfoProvider())
-
-        instance.logEvent(AppStartEvent())
-        instance.logEvent(AppStartEvent())
-        instance.logEvent(PurchaseSuccessfulEvent())
-        instance.logEvent(LoginSuccessfulEvent())
-        Mockito.verify(eventsManager, never()).onEventReceived(any(), any(), any())
-        (instance as InApp).tempEventList.shouldHaveSize(4)
-
-        instance.flushEventList()
-        instance.tempEventList.shouldBeEmpty()
-    }
-
-    @Test
-    fun `should log event if config is true`() {
-        val instance = initializeMockInstance(100)
-        instance.registerPreference(TestUserInfoProvider())
-
-        instance.logEvent(AppStartEvent())
-        Mockito.verify(eventsManager).onEventReceived(any(), any(), any())
-    }
-
-    @Test
     fun `should enable caching`() {
         initializeInstance(true)
 
         InAppMessaging.instance().isLocalCachingEnabled().shouldBeTrue()
-    }
-
-    @Test
-    fun `should call onSessionUpdate on user change`() {
-        val ctx = ApplicationProvider.getApplicationContext<Context>()
-        WorkManagerTestInitHelper.initializeTestWorkManager(ctx)
-        Settings.Secure.putString(ctx.contentResolver, Settings.Secure.ANDROID_ID, "test_device_id")
-
-        val accMock = Mockito.mock(AccountRepository::class.java)
-        val sessMock = Mockito.mock(SessionManager::class.java)
-        val instance = initializeMockInstance(100, accountRepo = accMock, sessionManager = sessMock)
-        val infoProvider = TestUserInfoProvider() // test_user_id
-        instance.registerPreference(infoProvider)
-
-        // Simulate change user
-        infoProvider.userId = "test_user_id_2"
-        `when`(accMock.updateUserInfo()).thenReturn(true)
-        (instance as InApp).userDidChange()
-
-        // Should call onSessionUpdate
-        verify(sessMock).onSessionUpdate()
     }
 
     @Test
@@ -400,6 +338,91 @@ class InAppMessagingConfigureSpec : InAppMessagingSpec() {
     }
 }
 
+class InAppMessagingLogEventSpec : InAppMessagingSpec() {
+    private val mockConfigRepo = Mockito.mock(ConfigResponseRepository::class.java)
+    private val mockEventUtil = Mockito.mock(EventMatchingUtil::class.java)
+    private val mockAcctRepo = Mockito.mock(AccountRepository::class.java)
+    private val mockCampaignRepo = Mockito.mock(CampaignRepository::class.java)
+    private val mockSessionManager = Mockito.mock(SessionManager::class.java)
+    private val mockEventsManager = Mockito.mock(EventsManager::class.java)
+
+    private val instance = initializeMockInstance(
+        rollout = 100,
+        configRepo = mockConfigRepo,
+        eventMatchingUtil = mockEventUtil,
+        accountRepo = mockAcctRepo,
+        campaignRepo = mockCampaignRepo,
+        sessionManager = mockSessionManager,
+        eventsManager = mockEventsManager,
+    )
+
+    @Test
+    fun `logEvent should not process event yet when config is not enabled`() {
+        `when`(mockConfigRepo.isConfigEnabled()).thenReturn(false)
+
+        val event = PurchaseSuccessfulEvent()
+        instance.logEvent(event)
+
+        verify(mockEventUtil).addToEventBuffer(event)
+    }
+
+    @Test
+    fun `logEvent should not process event yet when user changed`() {
+        `when`(mockConfigRepo.isConfigEnabled()).thenReturn(true)
+        `when`(mockAcctRepo.updateUserInfo()).thenReturn(true)
+
+        val event = PurchaseSuccessfulEvent()
+        instance.logEvent(event)
+
+        verify(mockEventUtil).addToEventBuffer(event)
+        verify(mockSessionManager).onSessionUpdate()
+    }
+
+    @Test
+    fun `logEvent should not process event yet when refreshing campaigns`() {
+        `when`(mockConfigRepo.isConfigEnabled()).thenReturn(true)
+        `when`(mockAcctRepo.updateUserInfo()).thenReturn(false)
+        `when`(mockCampaignRepo.lastSyncMillis).thenReturn(null)
+
+        val event = PurchaseSuccessfulEvent()
+        instance.logEvent(event)
+
+        verify(mockEventUtil).addToEventBuffer(event)
+    }
+
+    @Test
+    fun `logEvent should process event`() {
+        `when`(mockConfigRepo.isConfigEnabled()).thenReturn(true)
+        `when`(mockAcctRepo.updateUserInfo()).thenReturn(false)
+        `when`(mockCampaignRepo.lastSyncMillis).thenReturn(0)
+        `when`(mockEventUtil.tempEvents).thenReturn(arrayListOf())
+
+        val event = PurchaseSuccessfulEvent()
+        instance.logEvent(event)
+
+        verify(mockEventUtil, never()).addToEventBuffer(event)
+        verify(mockEventsManager).onEventReceived(event)
+    }
+
+    @Test
+    fun `logEvent should not crash due to forced exception`() {
+        `when`(mockConfigRepo.isConfigEnabled()).thenThrow(NullPointerException())
+
+        instance.logEvent(PurchaseSuccessfulEvent())
+    }
+
+    @Test
+    fun `logEvent should trigger callback due to forced exception`() {
+        `when`(mockConfigRepo.isConfigEnabled()).thenThrow(NullPointerException())
+        InAppMessaging.errorCallback = mockCallback
+
+        instance.logEvent(PurchaseSuccessfulEvent())
+
+        Mockito.verify(mockCallback).invoke(captor.capture())
+        captor.firstValue shouldBeInstanceOf InAppMessagingException::class.java
+    }
+}
+
 class InAppMessagingExceptionSpec : InAppMessagingSpec() {
 
     private val mockActivity = Mockito.mock(Activity::class.java)
@@ -470,25 +493,6 @@ class InAppMessagingExceptionSpec : InAppMessagingSpec() {
         captor.firstValue shouldBeInstanceOf InAppMessagingException::class.java
     }
 
-    @Test
-    fun `should not crash when log event failed due to forced exception`() {
-        instance.logEvent(AppStartEvent())
-    }
-
-    @Test
-    fun `should trigger callback when log event failed due to forced exception`() {
-        InAppMessaging.errorCallback = mockCallback
-        instance.logEvent(AppStartEvent())
-
-        Mockito.verify(mockCallback).invoke(captor.capture())
-        captor.firstValue shouldBeInstanceOf InAppMessagingException::class.java
-    }
-
-    @Test
-    fun `should not crash when save temp data failed due to forced exception`() {
-        instance.flushEventList()
-    }
-
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `should not crash when closing message due to forced exception`() = runTest {
@@ -548,7 +552,6 @@ class InAppMessagingUnInitSpec : InAppMessagingSpec() {
         InAppMessaging.instance().closeTooltip("ui-element")
         InAppMessaging.instance().isLocalCachingEnabled().shouldBeFalse()
         InAppMessaging.instance().trackPushPrimer(arrayOf(""), intArrayOf(1))
-        InAppMessaging.instance().flushEventList()
         InAppMessaging.instance().onPushPrimer.shouldBeNull()
     }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -379,7 +379,7 @@ class InAppMessagingLogEventSpec : InAppMessagingSpec() {
     }
 
     @Test
-    fun `logEvent should not process event yet when refreshing campaigns`() {
+    fun `logEvent should not process event yet when campaigns are not synced`() {
         `when`(mockConfigRepo.isConfigEnabled()).thenReturn(true)
         `when`(mockAcctRepo.updateUserInfo()).thenReturn(false)
         `when`(mockCampaignRepo.lastSyncMillis).thenReturn(null)
@@ -395,7 +395,7 @@ class InAppMessagingLogEventSpec : InAppMessagingSpec() {
         `when`(mockConfigRepo.isConfigEnabled()).thenReturn(true)
         `when`(mockAcctRepo.updateUserInfo()).thenReturn(false)
         `when`(mockCampaignRepo.lastSyncMillis).thenReturn(0)
-        `when`(mockEventUtil.tempEvents).thenReturn(arrayListOf())
+        `when`(mockEventUtil.eventBuffer).thenReturn(arrayListOf())
 
         val event = PurchaseSuccessfulEvent()
         instance.logEvent(event)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtilSpec.kt
@@ -267,7 +267,7 @@ class EventMatchingUtilEventBufferSpec : EventMatchingUtilSpec() {
         eventMatchingUtil.addToEventBuffer(AppStartEvent())
         eventMatchingUtil.addToEventBuffer(PurchaseSuccessfulEvent())
 
-        eventMatchingUtil.tempEvents.size.shouldBeEqualTo(2)
+        eventMatchingUtil.eventBuffer.size.shouldBeEqualTo(2)
     }
 
     @Test
@@ -277,6 +277,6 @@ class EventMatchingUtilEventBufferSpec : EventMatchingUtilSpec() {
 
         eventMatchingUtil.flushEventBuffer()
 
-        eventMatchingUtil.tempEvents.shouldBeEmpty()
+        eventMatchingUtil.eventBuffer.shouldBeEmpty()
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/EventMatchingUtilSpec.kt
@@ -260,3 +260,23 @@ class EventMatchingUtilClearSpec : EventMatchingUtilSpec() {
         eventMatchingUtil.triggeredPersistentCampaigns.shouldHaveSize(1)
     }
 }
+
+class EventMatchingUtilEventBufferSpec : EventMatchingUtilSpec() {
+    @Test
+    fun `should add to event buffer`() {
+        eventMatchingUtil.addToEventBuffer(AppStartEvent())
+        eventMatchingUtil.addToEventBuffer(PurchaseSuccessfulEvent())
+
+        eventMatchingUtil.tempEvents.size.shouldBeEqualTo(2)
+    }
+
+    @Test
+    fun `should flush event buffer`() {
+        eventMatchingUtil.addToEventBuffer(AppStartEvent())
+        eventMatchingUtil.addToEventBuffer(PurchaseSuccessfulEvent())
+
+        eventMatchingUtil.flushEventBuffer()
+
+        eventMatchingUtil.tempEvents.shouldBeEmpty()
+    }
+}

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
@@ -10,14 +10,11 @@ import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.never
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InApp
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessagingTestConstants
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.AppStartEvent
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.PurchaseSuccessfulEvent
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.config.ConfigResponse
@@ -175,40 +172,6 @@ class ConfigWorkerSuccessSpec : ConfigWorkerSpec() {
         `when`(mockResponse.body()).thenReturn(Mockito.mock(ConfigResponse::class.java))
         worker.onResponse(mockResponse) shouldBeEqualTo ListenableWorker.Result.Success()
         ConfigScheduler.currDelay shouldBeEqualTo RetryDelayUtil.INITIAL_BACKOFF_DELAY
-    }
-
-    @Test
-    fun `should log events when config is enabled`() {
-        setupMock(100)
-        initializeInstance()
-        InAppMessaging.instance().logEvent(AppStartEvent())
-        InAppMessaging.instance().logEvent(PurchaseSuccessfulEvent())
-        (InAppMessaging.instance() as InApp).tempEventList.shouldHaveSize(2)
-
-        val worker = ConfigWorker(
-            ctx, workParam, HostAppInfoRepository.instance(),
-            ConfigResponseRepository.instance(), mockMsgSched, mockConfigSched
-        )
-        worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.Success()
-        Mockito.verify(mockMsgSched).pingMessageMixerService(0)
-    }
-
-    @Test
-    fun `should clear temp events when config is disabled`() {
-        setupMock(0)
-
-        initializeInstance()
-        InAppMessaging.instance().logEvent(AppStartEvent())
-        InAppMessaging.instance().logEvent(PurchaseSuccessfulEvent())
-        (InAppMessaging.instance() as InApp).tempEventList.shouldHaveSize(2)
-
-        val worker = ConfigWorker(
-            ctx, workParam, HostAppInfoRepository.instance(),
-            ConfigResponseRepository.instance(), mockMsgSched, mockConfigSched
-        )
-        worker.onResponse(mockResponse!!) shouldBeEqualTo ListenableWorker.Result.Success()
-        InAppMessaging.instance() shouldBeInstanceOf InAppMessaging.NotConfiguredInAppMessaging::class.java
-        Mockito.verify(mockMsgSched, never()).pingMessageMixerService(0)
     }
 
     @Test


### PR DESCRIPTION
# Description
When app calls `logEvent()` API (esp. on `onCreate()`), there are instances that campaign list is empty, thus failing to match the event and campaign's triggers. This PR adds handling that campaign list should be at least synced to process that event.

## Links
SDKCF-6267

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
