### PR TITLE
tests: bump robolectric to `4.9.2` and increase default sdk (SDKCF-6092)

### DIFF
--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -78,7 +78,7 @@ dependencies {
   testImplementation 'androidx.work:work-testing:2.7.1'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.mockito:mockito-core:4.5.1'
-  testImplementation 'org.robolectric:robolectric:4.9'
+  testImplementation 'org.robolectric:robolectric:4.9.2'
   testImplementation "com.facebook.soloader:soloader:0.9.0"
   testImplementation "com.squareup.okhttp3:mockwebserver:3.14.7"
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/BaseTest.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/BaseTest.kt
@@ -1,15 +1,12 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime
 
-import android.os.Build
 import org.junit.After
 import org.junit.Before
 import org.mockito.Mockito
-import org.robolectric.annotation.Config
 
 /**
  * Base test class of all test classes.
  */
-@Config(sdk = [Build.VERSION_CODES.M])
 open class BaseTest {
     @Before
     open fun setup() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/EventTrackerHelperSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/EventTrackerHelperSpec.kt
@@ -1,18 +1,15 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime
 
-import android.os.Build
 import org.amshove.kluent.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Tests for EventTrackerHelper class.
  */
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class SendEventSpec(
     private val eventName: String,
     private val data: Map<String, *>?,
@@ -41,7 +38,6 @@ class SendEventSpec(
 }
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class HasClassSpec(
     private val className: String,
     private val expected: Boolean

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
@@ -41,7 +41,6 @@ import org.robolectric.annotation.Config
  * Test class for MessageActionsCoroutine
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 internal class MessageActionsCoroutineSpec(
     val testName: String,
     private val resourceId: Int,

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/ButtonActionTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/ButtonActionTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ButtonActionTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/CampaignTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/CampaignTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class CampaignTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/EventTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/EventTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class EventTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/ImpressionTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/ImpressionTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ImpressionTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/InAppMessageTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/InAppMessageTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class InAppMessageTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/OperatorTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/OperatorTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class OperatorTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/PositionTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/PositionTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class PositionTypeSpec(private val id: String, private val expected: Any?) {
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/SlideFromDirectionTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/SlideFromDirectionTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class SlideFromDirectionTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/ValueTypeSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/enums/ValueTypeSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.enums
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ValueTypeSpec(private val id: Int, private val expected: Any?) {
     @Test
     fun `should return correct type from id`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/CustomEventSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/CustomEventSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents
 
-import android.os.Build
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.ValueType
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
@@ -9,7 +8,6 @@ import org.amshove.kluent.shouldBeFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.Date
 
 /**
@@ -46,7 +44,6 @@ class CustomEventSpec : BaseTest() {
 }
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class CustomEventParameterizedSpec(
     val testName: String,
     private val attrType: ValueType,

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/EventSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/appevents/EventSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents
 
-import android.os.Build
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.EventType
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
@@ -8,14 +7,12 @@ import org.amshove.kluent.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.Locale
 
 /**
  * Test class for AppStartEvent.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class EventSpec(
     val eventName: String,
     val event: BaseEvent,

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/displaypermission/DisplayPermissionResponseSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/displaypermission/DisplayPermissionResponseSpec.kt
@@ -1,15 +1,12 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.displaypermission
 
-import android.os.Build
 import com.google.gson.Gson
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class DisplayPermissionResponseSpec(
     private val testname: String,
     private val actual: Boolean,

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignDataSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/CampaignDataSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping
 
-import android.os.Build
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.InAppMessageType
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
@@ -9,9 +8,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.M])
 class CampaignDataSpec {
 
     private val mockPayload = Mockito.mock(MessagePayload::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/responses/ping/MessageMixerResponseSpec.kt
@@ -1,17 +1,14 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping
 
-import android.os.Build
 import com.google.gson.Gson
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldHaveSize
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.io.File
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class MessageMixerResponseSpec(private val testname: String, private val actual: Any?, private val expected: Any?) {
     @Test
     fun `should be correct value after parsing`() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.integration
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker
@@ -23,10 +22,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class IntegrationSpec {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val workerParameters = Mockito.mock(WorkerParameters::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/ImpressionManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/ImpressionManagerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.manager
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkManager
@@ -23,7 +22,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.*
 import java.util.concurrent.ExecutionException
 
@@ -31,7 +29,6 @@ import java.util.concurrent.ExecutionException
  * Test class for ImpressionManager.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ImpressionManagerSpec : BaseTest() {
 
     private val eventTracker = Mockito.mock(EventTrackerHelper::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.manager
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -27,7 +26,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import retrofit2.Call
 import java.util.*
 import kotlin.collections.ArrayList
@@ -36,7 +34,6 @@ import kotlin.collections.ArrayList
  * Test class for MessageReadinessManager.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 open class MessageReadinessManagerSpec : BaseTest() {
     private var configResponseData = Mockito.mock(ConfigResponseData::class.java)
     private var configResponseEndpoints = Mockito.mock(ConfigResponseEndpoints::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnableSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnableSpec.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.runnable
 import android.app.Activity
 import android.content.Context
 import android.content.res.Resources
-import android.os.Build
 import android.provider.Settings
 import android.util.DisplayMetrics
 import android.view.LayoutInflater
@@ -31,13 +30,11 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Test class for DisplayMessageRunnable.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @SuppressWarnings("LargeClass")
 class DisplayMessageRunnableSpec : BaseTest() {
     private val message = mock(CampaignData::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageWorkerSpec.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.service
 import android.app.Activity
 import android.content.Context
 import android.content.res.Resources
-import android.os.Build
 import android.os.Handler
 import android.util.DisplayMetrics
 import android.view.View
@@ -37,13 +36,11 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.verification.VerificationMode
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Test class for DisplayMessageJobIntentService.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 open class DisplayMessageWorkerSpec : BaseTest() {
 
     private val activity = Mockito.mock(Activity::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/CacheUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/CacheUtilSpec.kt
@@ -1,14 +1,11 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
-import android.os.Build
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBePositive
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @RunWith(RobolectricTestRunner::class)
 class CacheUtilSpec {
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ImageUtilSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
 import android.content.Context
-import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -15,9 +14,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doAnswer
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @RunWith(RobolectricTestRunner::class)
 class ImageUtilSpec {
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -16,7 +16,6 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingEx
 import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
 import org.amshove.kluent.*
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -40,13 +39,12 @@ class InitializerSpec : BaseTest() {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
     fun `should add host app info with basic attributes`() {
         verifyHostAppInfo()
     }
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
-    @Ignore("API 33 is not yet supported in Robolectric v4.8.1")
     fun `should add host app info with basic attributes in API 33`() {
         verifyHostAppInfo()
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -39,12 +39,12 @@ class InitializerSpec : BaseTest() {
     }
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.M])
     fun `should add host app info with basic attributes`() {
         verifyHostAppInfo()
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     fun `should add host app info with basic attributes in API 33`() {
         verifyHostAppInfo()
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -16,6 +16,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingEx
 import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
 import org.amshove.kluent.*
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -45,6 +46,7 @@ class InitializerSpec : BaseTest() {
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Ignore("Robolectric returns null metadata for API 33")
     fun `should add host app info with basic attributes in API 33`() {
         verifyHostAppInfo()
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/MessageEventReconciliationUtilSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
-import android.os.Build
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.EventType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.InAppMessageType
@@ -18,13 +17,11 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Test class for MessageEventReconciliationUtil.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @Ignore("base class")
 open class MessageEventReconciliationUtilSpec : BaseTest() {
     internal val outdatedTestCampaign = CampaignData(

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ResourceUtilsSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ResourceUtilsSpec.kt
@@ -2,16 +2,13 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
 import android.app.Activity
 import android.content.res.Resources
-import android.os.Build
 import android.view.View
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import org.amshove.kluent.shouldBeNull
 import org.junit.Test
 import org.mockito.Mockito
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.M])
 class ResourceUtilsSpec {
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtilSpec.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
 import android.content.Context
 import android.content.res.Resources
-import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
@@ -21,13 +20,11 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Test class for ViewUtil.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @SuppressWarnings("LargeClass")
 class ViewUtilSpec : BaseTest() {
 
@@ -119,7 +116,6 @@ class ViewUtilSpec : BaseTest() {
 }
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ViewUtilGetTooltipPosition {
     private val mockContainer = mock(ViewGroup::class.java)
     private val mockAnchor = mock(View::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
@@ -219,7 +219,7 @@ class BaseViewColorSpec : BaseViewSpec() {
     @Test
     @Config(
         sdk = [
-            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.S,
             Build.VERSION_CODES.TIRAMISU
         ]
     )
@@ -233,7 +233,7 @@ class BaseViewColorSpec : BaseViewSpec() {
     @Test
     @Config(
         sdk = [
-            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.S,
             Build.VERSION_CODES.TIRAMISU
         ]
     )
@@ -248,7 +248,7 @@ class BaseViewColorSpec : BaseViewSpec() {
     @Test
     @Config(
         sdk = [
-            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.S,
             Build.VERSION_CODES.TIRAMISU
         ]
     )
@@ -359,7 +359,7 @@ class BaseViewTextSpec : BaseViewSpec() {
     @Test
     @Config(
         sdk = [
-            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.S,
             Build.VERSION_CODES.TIRAMISU
         ]
     )

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/BaseViewSpec.kt
@@ -37,9 +37,7 @@ import org.amshove.kluent.*
 import org.junit.Ignore
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
-import org.robolectric.util.ReflectionHelpers
 
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @RunWith(RobolectricTestRunner::class)
 @Ignore("base class")
 open class BaseViewSpec : BaseTest() {
@@ -52,14 +50,14 @@ open class BaseViewSpec : BaseTest() {
     internal val mockResource = Mockito.mock(Resource::class.java)
     internal val mockBtn = Mockito.mock(MessageButton::class.java)
     internal var view: InAppMessageBaseView? = null
+    internal var expectedHyphenation = Layout.HYPHENATION_FREQUENCY_NONE
 
     @Before
     override fun setup() {
         super.setup()
-        `when`(
-            hostAppActivity
-                .layoutInflater
-        ).thenReturn(LayoutInflater.from(ApplicationProvider.getApplicationContext()))
+        `when`(hostAppActivity.layoutInflater).thenReturn(
+            LayoutInflater.from(ApplicationProvider.getApplicationContext())
+        )
         `when`(mockMessage.getMessagePayload()).thenReturn(mockPayload)
         `when`(mockMessage.isCampaignDismissable()).thenReturn(true)
         `when`(mockPayload.header).thenReturn("test")
@@ -68,9 +66,12 @@ open class BaseViewSpec : BaseTest() {
         `when`(mockSettings.controlSettings).thenReturn(mockCtrlSettings)
         `when`(mockSettings.displaySettings).thenReturn(mockDisplaySettings)
         `when`(mockPayload.resource).thenReturn(mockResource)
-        view = hostAppActivity
-            .layoutInflater
-            .inflate(R.layout.in_app_message_full_screen, null) as InAppMessageBaseView
+        view = hostAppActivity.layoutInflater.inflate(R.layout.in_app_message_full_screen, null)
+            as InAppMessageBaseView
+
+        expectedHyphenation = if (Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU) {
+            Layout.HYPHENATION_FREQUENCY_FULL_FAST
+        } else Layout.HYPHENATION_FREQUENCY_FULL
     }
 
     companion object {
@@ -216,6 +217,12 @@ class BaseViewBorderSpec : BaseViewSpec() {
 
 class BaseViewColorSpec : BaseViewSpec() {
     @Test
+    @Config(
+        sdk = [
+            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.TIRAMISU
+        ]
+    )
     fun `should set default when invalid header color`() {
         `when`(mockPayload.headerColor).thenReturn("invalid")
         view?.populateViewData(mockMessage)
@@ -224,6 +231,12 @@ class BaseViewColorSpec : BaseViewSpec() {
     }
 
     @Test
+    @Config(
+        sdk = [
+            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.TIRAMISU
+        ]
+    )
     fun `should set default when invalid body color`() {
         `when`(mockPayload.headerColor).thenReturn(WHITE_HEX)
         `when`(mockPayload.messageBodyColor).thenReturn("incorrect")
@@ -233,6 +246,12 @@ class BaseViewColorSpec : BaseViewSpec() {
     }
 
     @Test
+    @Config(
+        sdk = [
+            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.TIRAMISU
+        ]
+    )
     fun `should set default when invalid bg color`() {
         `when`(mockPayload.headerColor).thenReturn(WHITE_HEX)
         `when`(mockPayload.messageBodyColor).thenReturn(WHITE_HEX)
@@ -278,11 +297,11 @@ class BaseViewColorSpec : BaseViewSpec() {
     private fun verifyDefault() {
         val header = view?.findViewById<TextView>(R.id.header_text)
         header?.textColors shouldBeEqualTo ColorStateList.valueOf(Color.BLACK)
-        header?.hyphenationFrequency shouldNotBeEqualTo Layout.HYPHENATION_FREQUENCY_NONE
+        header?.hyphenationFrequency shouldBe expectedHyphenation
 
         val body = view?.findViewById<TextView>(R.id.message_body)
         body?.textColors shouldBeEqualTo ColorStateList.valueOf(Color.BLACK)
-        body?.hyphenationFrequency shouldNotBeEqualTo Layout.HYPHENATION_FREQUENCY_NONE
+        body?.hyphenationFrequency shouldBe expectedHyphenation
     }
 }
 
@@ -338,13 +357,17 @@ class BaseViewTextSpec : BaseViewSpec() {
     }
 
     @Test
+    @Config(
+        sdk = [
+            Build.VERSION_CODES.Q,
+            Build.VERSION_CODES.TIRAMISU
+        ]
+    )
     fun `should set button hyphenation`() {
-        // Use "@Config" instead of setting SDK_INT once we upgrade robolectric with Tiramisu support
-        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.TIRAMISU)
         setMock()
 
         val btn = view?.findViewById<MaterialButton>(R.id.message_single_button)
-        btn?.hyphenationFrequency shouldNotBeEqualTo Layout.HYPHENATION_FREQUENCY_NONE
+        btn?.hyphenationFrequency shouldBe expectedHyphenation
     }
 
     @SuppressWarnings("LongMethod")

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/CustomOnTouchListenerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/CustomOnTouchListenerSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.view
 
-import android.os.Build
 import android.view.MotionEvent
 import android.view.View
 import android.widget.ScrollView
@@ -13,9 +12,7 @@ import org.amshove.kluent.shouldBeFalse
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.verification.VerificationMode
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.M])
 class CustomOnTouchListenerSpec {
 
     private val mockMotionEvent = Mockito.mock(MotionEvent::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListenerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListenerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.view
 
 import android.app.Activity
-import android.os.Build
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
@@ -34,7 +33,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
-import org.robolectric.annotation.Config
 
 /**
  * Test class for InAppMessageViewListener.
@@ -67,7 +65,6 @@ open class InAppMessageViewListenerSpec : BaseTest() {
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@Config(sdk = [Build.VERSION_CODES.Q])
 class InAppMessageViewListenerOnClickSpec : InAppMessageViewListenerSpec() {
     private val mockCheckbox = Mockito.mock(CheckBox::class.java)
 
@@ -105,7 +102,6 @@ class InAppMessageViewListenerOnClickSpec : InAppMessageViewListenerSpec() {
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@Config(sdk = [Build.VERSION_CODES.Q])
 class InAppMessageViewListenerOnTouchSpec : InAppMessageViewListenerSpec() {
     private val mockMotionEvent = Mockito.mock(MotionEvent::class.java)
     private val mockCheck = Mockito.mock(BuildVersionChecker::class.java)
@@ -299,7 +295,6 @@ class InAppMessageViewListenerOnTouchSpec : InAppMessageViewListenerSpec() {
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@Config(sdk = [Build.VERSION_CODES.Q])
 class InAppMessageViewListenerOnKeySpec : InAppMessageViewListenerSpec() {
 
     private val keyEvent = Mockito.mock(KeyEvent::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ConfigSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ConfigSchedulerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.OneTimeWorkRequest
@@ -21,13 +20,11 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Testing class of ConfigScheduler.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ConfigSchedulerSpec : BaseTest() {
 
     private val mockWorkManager = Mockito.mock(WorkManager::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationSchedulerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.OneTimeWorkRequest
@@ -25,14 +24,12 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.concurrent.ExecutionException
 
 /**
  * Test class for EventMessageReconciliationScheduler.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class EventMessageReconciliationSchedulerSpec : BaseTest() {
 
     private val mockWorkManager = Mockito.mock(WorkManager::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionSchedulerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkManager
@@ -25,13 +24,11 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Test class for ImpressionScheduler.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class ImpressionSchedulerSpec : BaseTest() {
 
     private val mockWorkManager = Mockito.mock(WorkManager::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers
 
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker
@@ -31,7 +30,6 @@ import org.junit.runner.RunWith
 import org.mockito.*
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import retrofit2.Response
 import java.net.HttpURLConnection
 
@@ -39,7 +37,6 @@ import java.net.HttpURLConnection
  * Test class for ConfigWorker.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @Ignore("base class")
 open class ConfigWorkerSpec : BaseTest() {
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ImpressionWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ImpressionWorkerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import android.util.Log
 import androidx.test.core.app.ApplicationProvider
@@ -32,7 +31,6 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import retrofit2.Call
 import retrofit2.Response
 import java.net.HttpURLConnection
@@ -42,7 +40,6 @@ import java.util.*
  * Test class for ImpressionWorker.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 @Ignore("base class")
 open class ImpressionWorkerSpec : BaseTest() {
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageEventReconciliationWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageEventReconciliationWorkerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers
 
 import android.content.Context
-import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.Data
 import androidx.work.ListenableWorker
@@ -20,13 +19,11 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Test for MessageEventReconciliationWorker class.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class MessageEventReconciliationWorkerSpec : BaseTest() {
 
     private val workerParameters = Mockito.mock(WorkerParameters::class.java)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorkerSpec.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers
 
 import android.content.Context
-import android.os.Build
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker
@@ -37,7 +36,6 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import retrofit2.Response
 import java.net.HttpURLConnection
 
@@ -45,7 +43,6 @@ import java.net.HttpURLConnection
  * Test class for MessageMixerWorker.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1])
 open class MessageMixerWorkerSpec : BaseTest() {
     @Mock
     internal val mockResp: Response<MessageMixerResponse>? = null

--- a/inappmessaging/src/test/resources/robolectric.properties
+++ b/inappmessaging/src/test/resources/robolectric.properties
@@ -1,3 +1,5 @@
 # Robolectric uses this file to configure all Robolectric tests within this package.
 manifest=AndroidManifest.xml
-sdk=29
+# Ideally, sdk should be same as targetSdk, however there is an issue in Robolectric where PackageManager metadata
+# is null, therefore breaking some tests. Set to a lower version.
+sdk=32

--- a/inappmessaging/src/test/resources/robolectric.properties
+++ b/inappmessaging/src/test/resources/robolectric.properties
@@ -1,5 +1,5 @@
 # Robolectric uses this file to configure all Robolectric tests within this package.
 manifest=AndroidManifest.xml
 # Ideally, sdk should be same as targetSdk, however there is an issue in Robolectric where PackageManager metadata
-# is null, therefore breaking some tests. Set to a lower version.
+# is null when sdk=33, therefore breaking some tests. Set to a lower version.
 sdk=32


### PR DESCRIPTION
# Description

- Bump robolectic to `4.9.2` for Android 13 support
- Removed boilerplate sdk setting in tests (by default use the sdk version in `robolectric.properties`)
- Updated default sdk to 32 (instead of 33, because there is an issue in Robolectric where metadata becomes null)

## Links
SDKCF-6092

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
