### PR TITLE
fix: unblock subsequent campaigns' display if previous is aborted through `onVerifyContext` (SDKCF-6440)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -488,6 +488,7 @@ Documents targeting Product Managers:
 * SDKCF-6126: Fixed incorrect tooltip position on scroll views and during device screen rotation.
 * SDKCF-6267: Fixed issue where campaign is sometimes not displayed on app launch.
 * SDKCF-6391: Fixed campaign being displayed multiple times when upgrading to version `7.2.0` or later.
+* SDKCF-6440: Fixed campaigns are not displayed when prior campaign in queue is cancelled through `onVerifyContext`.
 * SDKCF-6394: Refactored data classes to remove unnecessary annotation and grouped related data classes.
 
 ### 7.3.0 (2022-12-13)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
@@ -88,7 +88,8 @@ internal class DisplayMessageWorker(
         if (!verifyContexts(message)) {
             // Message display aborted by the host app
             InAppLogger(TAG).debug("message display cancelled by the host app")
-
+            // Remove message in queue and proceed to next message
+            messageReadinessManager.removeMessageFromQueue(message.getCampaignId())
             prepareNextMessage()
             return
         }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageWorkerSpec.kt
@@ -282,6 +282,13 @@ class DisplayMessageWorkerVerifyContextSpec : DisplayMessageWorkerSpec() {
         Mockito.verify(mockMessageManager, Mockito.times(2)).getNextDisplayMessage()
     }
 
+    @Test
+    fun `should remove message from queue when context was rejected`() {
+        setupNextCampaign()
+
+        Mockito.verify(mockMessageManager).removeMessageFromQueue("1")
+    }
+
     private fun setupNextCampaign(): Message {
         val message = Mockito.mock(Message::class.java)
 

--- a/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
+++ b/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
@@ -21,6 +21,7 @@ import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
 class MainActivityFragment : Fragment(), View.OnClickListener {
 
     private var tokenOrIdTrackingType = 0 // Use Tracking ID over access token by default
+    private var ignoredContexts = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         context?.let {
@@ -50,6 +51,7 @@ class MainActivityFragment : Fragment(), View.OnClickListener {
         view.findViewById<Button>(R.id.close_message).setOnClickListener(this)
         view.findViewById<Button>(R.id.close_tooltip).setOnClickListener(this)
         view.findViewById<Button>(R.id.reconfigure).setOnClickListener(this)
+        view.findViewById<Button>(R.id.set_contexts).setOnClickListener(this)
     }
 
     override fun onClick(v: View) {
@@ -78,8 +80,33 @@ class MainActivityFragment : Fragment(), View.OnClickListener {
             }
             R.id.close_tooltip -> openCloseTooltipDialog()
             R.id.reconfigure -> showConfiguration()
+            R.id.set_contexts -> setContexts()
             else -> Any()
         }
+    }
+
+    private fun setContexts() {
+        val contentView = LayoutInflater.from(activity).inflate(R.layout.dialog_contexts, null)
+        val viewId = contentView.findViewById<EditText>(R.id.edit_contexts)
+        viewId.setText(ignoredContexts)
+
+        val dialog = AlertDialog.Builder(activity)
+            .setView(contentView)
+            .setTitle("Set Contexts")
+            .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                ignoredContexts = viewId.text.toString().trim()
+                if (ignoredContexts.isNotEmpty()) {
+                    InAppMessaging.instance().onVerifyContext = { contexts, _ ->
+                        contexts.intersect(ignoredContexts.split(",").toSet()).isEmpty()
+                    }
+                }
+                dialog.dismiss()
+            }
+            .setNegativeButton(android.R.string.cancel) {dialog, _ ->
+                dialog.dismiss()
+            }
+            .create()
+        dialog.show()
     }
 
     private fun openCloseTooltipDialog() {

--- a/test/src/main/res/layout/dialog_contexts.xml
+++ b/test/src/main/res/layout/dialog_contexts.xml
@@ -1,0 +1,27 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/contexts_guide"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        android:text="@string/set_contexts_guide"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/edit_contexts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/contexts_guide" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/test/src/main/res/layout/fragment_main.xml
+++ b/test/src/main/res/layout/fragment_main.xml
@@ -10,6 +10,12 @@
   tools:showIn="@layout/activity_main">
 
   <Button
+      android:id="@+id/set_contexts"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/set_contexts"/>
+
+  <Button
       android:id="@+id/close_message"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/test/src/main/res/values/strings.xml
+++ b/test/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
   <string name="label_config_url">Config URL</string>
   <string name="label_subs_key">Subscription\nKey</string>
   <string name="sec_act_custom_event_click">sec_act_click_event</string>
+  <string name="set_contexts">Set Contexts</string>
+  <string name="set_contexts_guide">Enter comma-separated contexts:</string>
 </resources>


### PR DESCRIPTION
# Description
When app aborts a campaign through `onVerifyContext`, ignored campaign is not displayed but it blocks other ready campaigns because it is never removed from queue.

## Links
SDKCF-6440

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
