### PR TITLE
refactor: remove unused Retrofit utility function `getImage()` (SDKCF-6395)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -485,6 +485,7 @@ Documents targeting Product Managers:
 
 ### 7.4.0 (In-Progress)
 * SDKCF-6321: Updated detekt version to `1.22.0`.
+* SDKCF-6395: Removed unused Retrofit utility function `getImage()`.
 * SDKCF-6126: Fixed incorrect tooltip position on scroll views and during device screen rotation.
 * SDKCF-6267: Fixed issue where campaign is sometimes not displayed on app launch.
 * SDKCF-6391: Fixed campaign being displayed multiple times when upgrading to version `7.2.0` or later.

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -485,7 +485,7 @@ Documents targeting Product Managers:
 
 ### 7.4.0 (In-Progress)
 * SDKCF-6321: Updated detekt version to `1.22.0`.
-* SDKCF-6395: Removed unused Retrofit utility function `getImage()`.
+* SDKCF-6395: Removed unused utility function `getImage()` (downloading image with Retrofit).
 * SDKCF-6126: Fixed incorrect tooltip position on scroll views and during device screen rotation.
 * SDKCF-6267: Fixed issue where campaign is sometimes not displayed on app launch.
 * SDKCF-6391: Fixed campaign being displayed multiple times when upgrading to version `7.2.0` or later.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/api/MessageMixerRetrofitService.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/api/MessageMixerRetrofitService.kt
@@ -11,8 +11,6 @@ import retrofit2.http.POST
 import retrofit2.http.Header
 import retrofit2.http.Url
 import retrofit2.http.Body
-import retrofit2.http.Streaming
-import retrofit2.http.GET
 
 /**
  * Retrofit APIs interface in order to make requests to Message Mixer.
@@ -54,15 +52,6 @@ internal interface MessageMixerRetrofitService {
         @Url impressionUrl: String,
         @Body impressionRequest: ImpressionRequest,
     ): Call<ResponseBody>
-
-    // ----------------------------------- Downloading Image --------------------------------------
-    /**
-     * Retrofit to download image using dynamic URL from Azure Storage. Use ResponseBody only, so
-     * Retrofit won't convert image into object.
-     */
-    @Streaming
-    @GET
-    fun getImage(@Url imageUrl: String): Call<ResponseBody>
 
     companion object {
         const val DEVICE_ID_HEADER = "device_id"

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/RuntimeUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/RuntimeUtil.kt
@@ -1,16 +1,10 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.webkit.URLUtil
-import com.rakuten.tech.mobile.inappmessaging.runtime.api.MessageMixerRetrofitService
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.UserIdentifierType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.UserIdentifier
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
 import com.rakuten.tech.mobile.sdkutils.network.build
 import okhttp3.OkHttpClient
-import okhttp3.ResponseBody
-import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.Calendar
@@ -30,7 +24,6 @@ internal object RuntimeUtil {
         .build()
     private val EXECUTOR = Executors.newSingleThreadExecutor()
     private val GSON_CONVERTER_FACTORY = GsonConverterFactory.create()
-    private const val TAG = "IAM_RuntimeUtil"
 
     /**
      * This method returns a reference of Retrofit. Retrofit is handling API calls.
@@ -43,37 +36,6 @@ internal object RuntimeUtil {
             gsonConverterFactory = GSON_CONVERTER_FACTORY,
             executor = EXECUTOR,
         )
-    }
-
-    /**
-     * This method is a thread blocking GET request to retrieve image from server.
-     * Returns null if call was failed.
-     * Throws IOException if an error occur when making Get request, or converting image data
-     * into bytes.
-     */
-    fun getImage(imageUrl: String): Bitmap? {
-        if (URLUtil.isNetworkUrl(imageUrl)) {
-            return fetchImage(imageUrl)
-        }
-        return null
-    }
-
-    @SuppressWarnings("TooGenericExceptionCaught")
-    private fun fetchImage(imageUrl: String): Bitmap? {
-        val getImageCall: Call<ResponseBody> =
-            getRetrofit().create(MessageMixerRetrofitService::class.java).getImage(imageUrl)
-        try {
-            val imageResponse = getImageCall.execute()
-            if (imageResponse.isSuccessful) {
-                imageResponse.body()?.let { body ->
-                    val bytes = body.bytes() // should no longer be null
-                    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                }
-            }
-        } catch (ex: Exception) {
-            InAppLogger(TAG).debug(ex.message)
-        }
-        return null
     }
 
     /**

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/RuntimeUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/RuntimeUtilSpec.kt
@@ -51,9 +51,4 @@ class RuntimeUtilSpec : BaseTest() {
         retrofit.converterFactories().shouldNotBeNull()
         retrofit.callbackExecutor().shouldNotBeNull()
     }
-
-    @Test
-    fun `should get null with invalid url`() {
-        RuntimeUtil.getImage("https://test.jpg").shouldBeNull()
-    }
 }


### PR DESCRIPTION
# Description
This function is unused (only in tests). We already changed the implementation to use Picasso for downloading image.

## Links
SDKCF-6395

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
