### PR TITLE
tests: increase coverage for InAppMessagingConstants (SDKCF-6479)

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepository.kt
@@ -4,12 +4,12 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.ARGUMENT_IS_NULL_EXCEPTION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.DEVICE_ID_IS_EMPTY_EXCEPTION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.LOCALE_IS_EMPTY_EXCEPTION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.PACKAGE_NAME_IS_EMPTY_EXCEPTION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.SUBSCRIPTION_KEY_IS_EMPTY_EXCEPTION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.VERSION_IS_EMPTY_EXCEPTION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.ARGUMENT_IS_NULL_EXCEPTION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.DEVICE_ID_IS_EMPTY_EXCEPTION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.LOCALE_IS_EMPTY_EXCEPTION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.PACKAGE_NAME_IS_EMPTY_EXCEPTION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.SUBSCRIPTION_KEY_IS_EMPTY_EXCEPTION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.VERSION_IS_EMPTY_EXCEPTION
 import java.util.Locale
 
 /**

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/ImpressionManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/ImpressionManager.kt
@@ -8,10 +8,10 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppI
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.requests.Impression
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.requests.ImpressionRequest
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_CAMP_ID
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_IMP
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_KEY_IMPRESSION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_SUBS_ID
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_CAMP_ID
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_IMP
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_KEY_IMPRESSION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_SUBS_ID
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RuntimeUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.ImpressionScheduler
 import java.util.Date

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InAppMessagingConstants.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InAppMessagingConstants.kt
@@ -3,33 +3,30 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 /**
  * Constants class for In App Messaging.
  */
-internal class InAppMessagingConstants {
-    companion object {
-        const val ANDROID_PLATFORM_ENUM = 2
+internal object InAppMessagingConstants {
+    const val ANDROID_PLATFORM_ENUM = 2
 
-        // ------------------------------Exception Messages-----------------------------------------------
-        const val EVENT_NAME_EMPTY_EXCEPTION = "Event name can't be empty."
-        const val EVENT_NAME_TOO_LONG_EXCEPTION = "Event name can't exceed 255 characters."
-        const val ARGUMENT_IS_NULL_EXCEPTION = "Argument can't be null."
-        const val ARGUMENT_IS_EMPTY_EXCEPTION = "Argument value is empty."
-        const val VERSION_IS_EMPTY_EXCEPTION = "Version not found in context"
-        const val PACKAGE_NAME_IS_EMPTY_EXCEPTION = "Package Name not found in context"
-        const val LOCALE_IS_EMPTY_EXCEPTION = "Device locale not found in context"
-        const val DEVICE_ID_IS_EMPTY_EXCEPTION = "Device ID not found in context"
-        const val SUBSCRIPTION_KEY_IS_EMPTY_EXCEPTION = "InAppMessaging Subscription Key was not found in context"
+    // ------------------------------Exception Messages-----------------------------------------------
+    const val EVENT_NAME_EMPTY_EXCEPTION = "Event name can't be empty."
+    const val EVENT_NAME_TOO_LONG_EXCEPTION = "Event name can't exceed 255 characters."
+    const val ARGUMENT_IS_NULL_EXCEPTION = "Argument can't be null."
+    const val VERSION_IS_EMPTY_EXCEPTION = "Version not found in context"
+    const val PACKAGE_NAME_IS_EMPTY_EXCEPTION = "Package Name not found in context"
+    const val LOCALE_IS_EMPTY_EXCEPTION = "Device locale not found in context"
+    const val DEVICE_ID_IS_EMPTY_EXCEPTION = "Device ID not found in context"
+    const val SUBSCRIPTION_KEY_IS_EMPTY_EXCEPTION = "InAppMessaging Subscription Key was not found in context"
 
-        // -------------------------------URL Only--------------------------------------------------------
-        const val TEMPLATE_BASE_URL = "http://your.base.url/"
+    // -------------------------------URL Only--------------------------------------------------------
+    const val TEMPLATE_BASE_URL = "http://your.base.url/"
 
-        // ------------------------------ Analytics Event KEYS ---------------------------------------------
-        const val RAT_EVENT_KEY_IMPRESSION = "_rem_iam_impressions"
-        const val RAT_EVENT_KEY_PRIMER = "_rem_iam_pushprimer"
-        const val RAT_EVENT_KEY_EVENT_NAME = "eventName"
-        const val RAT_EVENT_KEY_EVENT_TIMESTAMP = "timestamp"
-        const val RAT_EVENT_KEY_EVENT_CUSTOM_ATTRIBUTE = "customAttributes"
-        const val RAT_EVENT_CAMP_ID = "campaign_id"
-        const val RAT_EVENT_SUBS_ID = "subscription_id"
-        const val RAT_EVENT_IMP = "impressions"
-        const val RAT_EVENT_KEY_PERMISSION = "push_permission"
-    }
+    // ------------------------------ Analytics Event KEYS ---------------------------------------------
+    const val RAT_EVENT_KEY_IMPRESSION = "_rem_iam_impressions"
+    const val RAT_EVENT_KEY_PRIMER = "_rem_iam_pushprimer"
+    const val RAT_EVENT_KEY_EVENT_NAME = "eventName"
+    const val RAT_EVENT_KEY_EVENT_TIMESTAMP = "timestamp"
+    const val RAT_EVENT_KEY_EVENT_CUSTOM_ATTRIBUTE = "customAttributes"
+    const val RAT_EVENT_CAMP_ID = "campaign_id"
+    const val RAT_EVENT_SUBS_ID = "subscription_id"
+    const val RAT_EVENT_IMP = "impressions"
+    const val RAT_EVENT_KEY_PERMISSION = "push_permission"
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/PushPrimerTrackerManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/PushPrimerTrackerManagerSpec.kt
@@ -6,10 +6,10 @@ import com.nhaarman.mockitokotlin2.verify
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.EventTrackerHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_CAMP_ID
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_KEY_PERMISSION
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_KEY_PRIMER
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.Companion.RAT_EVENT_SUBS_ID
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_CAMP_ID
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_KEY_PERMISSION
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_KEY_PRIMER
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants.RAT_EVENT_SUBS_ID
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before


### PR DESCRIPTION
# Description
This class is not instantiated causing low coverage , and since it does not have special implementation - can be made static (object).

## Links
SDKCF=6479

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
