### PR TITLE
tests: increase coverage for InAppMessageSlideUpView (SDKCF-6478)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -483,6 +483,10 @@ Documents targeting Product Managers:
 
 ## <a name="changelog"></a> Changelog
 
+### 7.5.0 (In-Progress)
+* Refactored the following classes to increase code coverage:
+  - InAppMessageSlideUpView (SDKCF-6478)
+
 ### 7.4.0 (In-Progress)
 * SDKCF-6321: Updated detekt version to `1.22.0`.
 * SDKCF-6395: Removed unused utility function `getImage()` (downloading image with Retrofit).

--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -484,7 +484,8 @@ Documents targeting Product Managers:
 ## <a name="changelog"></a> Changelog
 
 ### 7.5.0 (In-Progress)
-* Refactored the following classes to increase code coverage:
+* Improved the following classes to increase code coverage:
+  - InAppMessagingConstants (SDKCF-6497)
   - InAppMessageSlideUpView (SDKCF-6478)
 
 ### 7.4.0 (In-Progress)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageSlideUpView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageSlideUpView.kt
@@ -27,18 +27,17 @@ internal class InAppMessageSlideUpView(
         val constraintLayout = findViewById<ConstraintLayout>(R.id.slide_up)
 
         // Setting background color.
-        constraintLayout?.setBackgroundColor(bgColor)
+        constraintLayout.setBackgroundColor(bgColor)
         // Start animation based on direction.
-        val animation = ViewUtil.getSlidingAnimation(
+        ViewUtil.getSlidingAnimation(
             context,
             SlideFromDirectionType.getById(
                 message.messagePayload.messageSettings.displaySettings.slideFrom,
             ),
-        )
-        animation?.let {
-            constraintLayout?.startAnimation(it)
+        )?.let { animation ->
+            constraintLayout.startAnimation(animation)
         }
         // Set listener for special handling of the invisible constraints(button) click.
-        constraintLayout?.setOnClickListener(listener)
+        constraintLayout.setOnClickListener(listener)
     }
 }


### PR DESCRIPTION
# Description
Removed unnecessary null check causing low coverage.

## Links
SDKCF-6478

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
