### PR TITLE
fix: `NetworkOnMainThreadException` when campaign is cancelled through contexts

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
@@ -10,7 +10,6 @@ import androidx.work.WorkerParameters
 import androidx.work.WorkManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
-import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ImageUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.runnable.DisplayMessageRunnable
@@ -91,7 +90,7 @@ internal class DisplayMessageWorker(
             // Remove message in queue
             messageReadinessManager.removeMessageFromQueue(message.campaignId)
             // Prepare next message
-            if (newWorker) DisplayManager.instance().displayMessage() else prepareNextMessage()
+            if (newWorker) enqueueWork() else prepareNextMessage()
             return
         }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
@@ -10,6 +10,7 @@ import androidx.work.WorkerParameters
 import androidx.work.WorkManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
+import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ImageUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.runnable.DisplayMessageRunnable
@@ -70,7 +71,9 @@ internal class DisplayMessageWorker(
             imageUrl = imageUrl,
             callback = object : Callback {
                 override fun onSuccess() {
-                    displayMessage(message, hostActivity)
+                    // Picasso callbacks run on main thread
+                    // Prepare for next message off the main thread if this message is cancelled
+                    displayMessage(message, hostActivity, true)
                 }
 
                 override fun onError(e: Exception?) {
@@ -81,19 +84,18 @@ internal class DisplayMessageWorker(
         )
     }
 
-    /**
-     * This method displays message on UI thread.
-     */
-    private fun displayMessage(message: Message, hostActivity: Activity) {
+    private fun displayMessage(message: Message, hostActivity: Activity, newWorker: Boolean = false) {
         if (!verifyContexts(message)) {
             // Message display aborted by the host app
             InAppLogger(TAG).debug("message display cancelled by the host app")
-            // Remove message in queue and proceed to next message
+            // Remove message in queue
             messageReadinessManager.removeMessageFromQueue(message.campaignId)
-            prepareNextMessage()
+            // Prepare next message
+            if (newWorker) DisplayManager.instance().displayMessage() else prepareNextMessage()
             return
         }
 
+        // Display message on main thread
         handler.post(DisplayMessageRunnable(message, hostActivity))
     }
 


### PR DESCRIPTION
# Description
Picasso callbacks are run on main thread, therefore when a campaign with image reaches the `onSuccess` callback and host apps cancels the campaign, preparing for next message will happen in main thread and might take long time to process, thus causing this exception.

Prepare the next message on a separate worker to fix this issue.

An addition to PR: https://github.com/rakutentech/android-inappmessaging/pull/322

## Links
SDKCF-6440

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
