### PR TITLE
chore: make dependency check configurable via env variable

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,6 +40,7 @@ workflows:
     steps:
     - script@1:
         title: Dependency Check
+        run_if: '{{enveq "RUN_DEPENDENCY_CHECK" "true"}}'
         inputs:
         - content: ./gradlew dependencyCheckAggregate
     - script@1:


### PR DESCRIPTION
# Description
Dependency check enabled by default, but this should be configurable because there are cases downloading from DB fails due to network issues or other issues that can take 1 or more day to resolve externally.
