### PR TITLE
refactor: improve coverage for MessageReadinessManager (SDKCF-6458)

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InApp.kt
@@ -85,7 +85,6 @@ internal class InApp(
                 displayManager.removeMessage(hostAppInfoRepo.getRegisteredActivity(), removeAll = true)
             }
             hostAppInfoRepo.registerActivity(null)
-            // activityWeakReference?.clear()
         } catch (ex: Exception) {
             errorCallback?.let {
                 it(InAppMessagingException("In-App Messaging unregister activity failed", ex))

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessaging.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime
 import android.app.Activity
 import android.content.Context
 import androidx.annotation.NonNull
-import androidx.annotation.Nullable
 import androidx.annotation.RestrictTo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.AccountRepository
@@ -54,20 +53,6 @@ abstract class InAppMessaging internal constructor() {
      * triggers are satisfied, then display that message if all trigger conditions are satisfied.
      */
     abstract fun logEvent(@NonNull event: Event)
-
-    /**
-     * This method returns registered activity of the host app.
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
-    @Nullable
-    internal abstract fun getRegisteredActivity(): Activity?
-
-    /**
-     * This method returns application context of the host app.
-     */
-    @Nullable
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
-    internal abstract fun getHostAppContext(): Context?
 
     /**
      * This method returns flag if local caching feature is enabled.
@@ -174,7 +159,10 @@ abstract class InAppMessaging internal constructor() {
             // `manifestConfig.isDebugging()` is used to enable/disable the debug logging of InAppMessaging SDK.
             // Note: All InAppMessaging SDK logs' tags begins with "IAM_".
             if (instance is NotConfiguredInAppMessaging) {
-                instance = InApp(context, manifestConfig.isDebugging(), isCacheHandling = isCacheHandling)
+                instance = InApp(
+                    isDebugLogging = manifestConfig.isDebugging(),
+                    isCacheHandling = isCacheHandling,
+                )
             }
 
             val subsKeyTrim = subscriptionKey?.trim()
@@ -210,10 +198,6 @@ abstract class InAppMessaging internal constructor() {
         override fun unregisterMessageDisplayActivity() = Unit
 
         override fun logEvent(event: Event) = Unit
-
-        override fun getRegisteredActivity(): Activity? = null
-
-        override fun getHostAppContext(): Context? = null
 
         override fun isLocalCachingEnabled() = isCacheHandling
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutine.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutine.kt
@@ -17,6 +17,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.ValueType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.CustomEvent
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.Event
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.CampaignRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.OnClickBehavior
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Trigger
@@ -154,7 +155,7 @@ internal class MessageActionsCoroutine(
 
     private fun handleDeeplinkRedirection(uri: String?) {
         // Always use activity context.
-        val activityContext = InAppMessaging.instance().getRegisteredActivity()
+        val activityContext = HostAppInfoRepository.instance().getRegisteredActivity()
         if (!uri.isNullOrEmpty() && activityContext != null) {
             // Build an implicit intent.
             val intent = Intent(Intent.ACTION_DEFAULT, Uri.parse(uri))
@@ -181,7 +182,7 @@ internal class MessageActionsCoroutine(
 
     @SuppressLint("InlinedApi")
     private fun requestPushPrimer() {
-        InAppMessaging.instance().getRegisteredActivity()?.let { act ->
+        HostAppInfoRepository.instance().getRegisteredActivity()?.let { act ->
             ActivityCompat.requestPermissions(
                 act, arrayOf(Manifest.permission.POST_NOTIFICATIONS), InAppMessaging.PUSH_PRIMER_REQ_CODE,
             )

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/HostAppInfo.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/HostAppInfo.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.models
 
+import android.content.Context
 import java.util.Locale
 
 /**
@@ -13,4 +14,5 @@ internal data class HostAppInfo(
     internal val locale: Locale? = null,
     internal val configUrl: String? = null,
     internal val isTooltipFeatureEnabled: Boolean? = null,
+    internal val context: Context? = null,
 )

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/AccountRepository.kt
@@ -48,7 +48,7 @@ internal abstract class AccountRepository {
      * longer be used.
      */
     abstract fun clearUserOldCacheStructure(
-        context: Context? = InAppMessaging.instance().getHostAppContext(),
+        context: Context? = HostAppInfoRepository.instance().getContext(),
         preferences: PreferencesUtil = PreferencesUtil,
     )
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/CampaignRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/CampaignRepository.kt
@@ -146,7 +146,7 @@ internal abstract class CampaignRepository {
         }
 
         private fun retrieveData(): String {
-            return InAppMessaging.instance().getHostAppContext()?.let { ctx ->
+            return HostAppInfoRepository.instance().getContext()?.let { ctx ->
                 PreferencesUtil.getString(
                     context = ctx,
                     name = InAppMessaging.getPreferencesFile(),
@@ -158,7 +158,7 @@ internal abstract class CampaignRepository {
 
         private fun saveDataToCache() {
             if (InAppMessaging.instance().isLocalCachingEnabled()) {
-                InAppMessaging.instance().getHostAppContext()?.let {
+                HostAppInfoRepository.instance().getContext()?.let {
                     PreferencesUtil.putString(
                         context = it,
                         name = InAppMessaging.getPreferencesFile(),

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepository.kt
@@ -66,6 +66,11 @@ internal interface HostAppInfoRepository {
     fun isTooltipFeatureEnabled(): Boolean
 
     /**
+     * Returns the context which is provided by host apps during InAppMessaging.configure.
+     */
+    fun getContext(): Context?
+
+    /**
      * Clears host app info for testing.
      */
     @VisibleForTesting
@@ -83,16 +88,6 @@ internal interface HostAppInfoRepository {
      */
     fun getRegisteredActivity(): Activity?
 
-    /**
-     * Sets the application context, which is provided by host apps during InAppMessaging.configure.
-     */
-    fun setContext(context: Context)
-
-    /**
-     * Returns the context.
-     */
-    fun getContext(): Context?
-
     companion object {
         private const val TAG = "IAM_HostAppRepository"
         private var instance: HostAppInfoRepository = HostAppInfoRepositoryImpl()
@@ -103,7 +98,6 @@ internal interface HostAppInfoRepository {
     private class HostAppInfoRepositoryImpl : HostAppInfoRepository {
         @Volatile
         private var hostAppInfo: HostAppInfo? = null
-        private var context: Context? = null
         private var activity: WeakReference<Activity>? = null
 
         @Throws(InAppMessagingException::class)
@@ -146,6 +140,8 @@ internal interface HostAppInfoRepository {
 
         override fun isTooltipFeatureEnabled(): Boolean = hostAppInfo?.isTooltipFeatureEnabled == true
 
+        override fun getContext(): Context? = hostAppInfo?.context
+
         override fun clearInfo() {
             hostAppInfo = null
         }
@@ -159,11 +155,5 @@ internal interface HostAppInfoRepository {
         }
 
         override fun getRegisteredActivity() = this.activity?.get()
-
-        override fun setContext(context: Context) {
-            this.context = context
-        }
-
-        override fun getContext() = this.context
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/DisplayManager.kt
@@ -8,10 +8,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.coroutine.MessageActionsCoroutine
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.CampaignRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ResourceUtils
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers.DisplayMessageWorker
@@ -194,7 +194,7 @@ internal interface DisplayManager {
         }
 
         override fun removeHiddenTargets(parent: ViewGroup) {
-            val activity = InAppMessaging.instance().getRegisteredActivity() ?: return
+            val activity = HostAppInfoRepository.instance().getRegisteredActivity() ?: return
             activity.findViewById<FrameLayout>(R.id.in_app_message_tooltip_layout)?.let { frameLayout ->
                 val removeList = mutableListOf<View>()
                 for (i in 0 until frameLayout.childCount) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.manager
 
-import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.rakuten.tech.mobile.inappmessaging.runtime.BuildConfig
@@ -15,12 +14,11 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.data.requests.DisplayPermi
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.DisplayPermissionResponse
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
-import com.rakuten.tech.mobile.inappmessaging.runtime.extensions.isVisible
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
-import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ResourceUtils
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RetryDelayUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RuntimeUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.WorkerUtils
+import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ViewUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.schedulers.MessageMixerPingScheduler
 import retrofit2.Call
 import retrofit2.Response
@@ -31,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * The MessageReadinessManager dispatches the actual work to check if a message is ready to display.
  * Returns the next ready to display message.
  */
-internal interface MessageReadinessManager {
+internal interface ReadinessManager {
     /**
      * Adds a message by Id as ready for display.
      */
@@ -64,223 +62,239 @@ internal interface MessageReadinessManager {
      */
     @VisibleForTesting
     fun getDisplayCall(displayPermissionUrl: String, request: DisplayPermissionRequest): Call<DisplayPermissionResponse>
+}
+
+@SuppressWarnings(
+    "TooManyFunctions",
+    "LargeClass",
+    "LongParameterList",
+)
+internal class MessageReadinessManager(
+    val inAppMessaging: InAppMessaging,
+    val campaignRepo: CampaignRepository,
+    val configResponseRepo: ConfigResponseRepository,
+    val hostAppInfoRepo: HostAppInfoRepository,
+    val accountRepo: AccountRepository,
+    val pingScheduler: MessageMixerPingScheduler,
+    val viewUtil: ViewUtil,
+) : ReadinessManager {
+    private val queuedMessages = mutableListOf<String>()
+    private val queuedTooltips = mutableListOf<String>()
+
+    override fun addMessageToQueue(id: String) {
+        val message = campaignRepo.messages[id] ?: return
+        val queue = if (message.type == InAppMessageType.TOOLTIP.typeId) queuedTooltips else queuedMessages
+        synchronized(queue) { queue.add(id) }
+    }
+
+    override fun removeMessageFromQueue(id: String) {
+        val message = campaignRepo.messages[id] ?: return
+        val queue = if (message.type == InAppMessageType.TOOLTIP.typeId) queuedTooltips else queuedMessages
+        synchronized(queue) { queue.remove(id) }
+    }
+
+    override fun clearMessages() {
+        synchronized(queuedMessages) {
+            queuedMessages.clear()
+        }
+    }
+
+    @WorkerThread
+    @SuppressWarnings("LongMethod", "ComplexMethod", "ReturnCount")
+    override fun getNextDisplayMessage(): List<Message> {
+        shouldRetry.set(true)
+        val result = mutableListOf<Message>()
+        val hasCampaignsInQueue = queuedMessages.isNotEmpty()
+        // toList() to prevent ConcurrentModificationException
+        val queuedMessagesCopy = if (hasCampaignsInQueue) queuedMessages.toList() else queuedTooltips.toList()
+        for (messageId in queuedMessagesCopy) {
+            val message = campaignRepo.messages[messageId]
+            if (message == null) {
+                InAppLogger(TAG).debug("Queued campaign $messageId does not exist in the repository anymore")
+                continue
+            }
+
+            InAppLogger(TAG).debug("checking permission for message: %s", message.campaignId)
+
+            // First, check if this message should be displayed.
+            if (!shouldDisplayMessage(message)) {
+                InAppLogger(TAG).debug("skipping message: %s", message.campaignId)
+                // Skip to next message.
+                continue
+            }
+
+            // If message is test message, no need to do more checks.
+            if (shouldPing(message, result)) break
+
+            // Multiple tooltips can be displayed, checked other from queue.
+            if (queuedTooltips.isNotEmpty()) {
+                continue
+            } else if (result.isNotEmpty()) return result
+        }
+        return result
+    }
+
+    private fun shouldPing(message: Message, result: MutableList<Message>) = if (message.isTest) {
+        InAppLogger(TAG).debug("skipping test message: %s", message.campaignId)
+        result.add(message)
+        false
+    } else {
+        // Check message display permission with server.
+        val displayPermissionResponse = getMessagePermission(message)
+        // If server wants SDK to ping for updated messages, do a new ping request and break this loop.
+        when {
+            (displayPermissionResponse != null) && displayPermissionResponse.shouldPing -> {
+                // reset current delay to initial
+                MessageMixerPingScheduler.currDelay = RetryDelayUtil.INITIAL_BACKOFF_DELAY
+                pingScheduler.pingMessageMixerService(0)
+                true
+            }
+            isMessagePermissibleToDisplay(displayPermissionResponse) -> {
+                result.add(message)
+                false
+            }
+            else -> false
+        }
+    }
+
+    @VisibleForTesting
+    override fun getDisplayPermissionRequest(message: Message): DisplayPermissionRequest {
+        return DisplayPermissionRequest(
+            campaignId = message.campaignId,
+            appVersion = hostAppInfoRepo.getVersion(),
+            sdkVersion = BuildConfig.VERSION_NAME,
+            locale = hostAppInfoRepo.getDeviceLocale(),
+            lastPingInMillis = campaignRepo.lastSyncMillis ?: 0,
+            userIdentifier = RuntimeUtil.getUserIdentifiers(),
+        )
+    }
+
+    @VisibleForTesting
+    override fun getDisplayCall(
+        displayPermissionUrl: String,
+        request: DisplayPermissionRequest,
+    ): Call<DisplayPermissionResponse> = RuntimeUtil.getRetrofit()
+        .create(MessageMixerRetrofitService::class.java)
+        .getDisplayPermissionService(
+            subscriptionId = hostAppInfoRepo.getSubscriptionKey(),
+            accessToken = accountRepo.getAccessToken(),
+            url = displayPermissionUrl,
+            request = request,
+        )
+
+    /**
+     * This method checks if the message has infinite impressions, or has been displayed less
+     * than its max impressions, or has been opted out.
+     * Additional checks are performed depending on message type.
+     */
+    private fun shouldDisplayMessage(message: Message): Boolean {
+        val impressions = message.impressionsLeft ?: message.maxImpressions
+        val isOptOut = message.isOptedOut == true
+        val hasPassedBasicCheck = (message.areImpressionsInfinite || impressions > 0) && !isOptOut
+
+        return if (message.type == InAppMessageType.TOOLTIP.typeId) {
+            val shouldDisplayTooltip = hasPassedBasicCheck &&
+                isTooltipTargetViewVisible(message) // if view where to attach tooltip is indeed visible
+            shouldDisplayTooltip
+        } else {
+            hasPassedBasicCheck
+        }
+    }
+
+    private fun isTooltipTargetViewVisible(message: Message): Boolean {
+        val activity = inAppMessaging.getRegisteredActivity()
+        val id = message.getTooltipConfig()?.id
+
+        if (activity != null && id != null) {
+            return viewUtil.isViewByNameVisible(activity, id)
+        }
+        return false
+    }
+
+    /**
+     * This method returns if message is permissible to be displayed according to the message.
+     * display permission response parameter.
+     */
+    private fun isMessagePermissibleToDisplay(response: DisplayPermissionResponse?): Boolean =
+        response != null && response.display
+
+    /**
+     * This method returns display message permission (from server).
+     */
+    private fun getMessagePermission(message: Message): DisplayPermissionResponse? {
+        // Prepare request data.
+        val displayPermissionUrl: String = configResponseRepo.getDisplayPermissionEndpoint()
+        if (displayPermissionUrl.isEmpty()) return null
+
+        // Prepare network request.
+        val request = getDisplayPermissionRequest(message)
+        val permissionCall: Call<DisplayPermissionResponse> =
+            getDisplayCall(displayPermissionUrl, request)
+        accountRepo.logWarningForUserInfo(TAG)
+        return executeDisplayRequest(permissionCall)
+    }
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    private fun executeDisplayRequest(call: Call<DisplayPermissionResponse>): DisplayPermissionResponse? {
+        return try {
+            val response = call.execute()
+            handleResponse(response, call.clone())
+        } catch (e: Exception) {
+            checkAndRetry(call.clone()) {
+                InAppLogger(DISP_TAG).error(e.message)
+                InAppMessaging.errorCallback?.let {
+                    it(InAppMessagingException("In-App Messaging display permission request failed", e))
+                }
+            }
+        }
+    }
+
+    private fun handleResponse(
+        response: Response<DisplayPermissionResponse>,
+        callClone: Call<DisplayPermissionResponse>,
+    ): DisplayPermissionResponse? {
+        return when {
+            response.isSuccessful -> {
+                InAppLogger(DISP_TAG).debug(
+                    "display: %b performPing: %b", response.body()?.display, response.body()?.shouldPing,
+                )
+                response.body()
+            }
+            response.code() >= HttpURLConnection.HTTP_INTERNAL_ERROR -> checkAndRetry(callClone) {
+                WorkerUtils.logRequestError(DISP_TAG, response.code(), response.errorBody()?.string())
+            }
+            else -> {
+                WorkerUtils.logRequestError(DISP_TAG, response.code(), response.errorBody()?.string())
+                null
+            }
+        }
+    }
+
+    private fun checkAndRetry(
+        call: Call<DisplayPermissionResponse>,
+        errorHandling: () -> Unit,
+    ): DisplayPermissionResponse? {
+        return if (shouldRetry.getAndSet(false)) {
+            executeDisplayRequest(call)
+        } else {
+            errorHandling.invoke()
+            null
+        }
+    }
 
     companion object {
         private const val TAG = "IAM_MsgReadinessManager"
         private const val DISP_TAG = "IAM_DisplayPermission"
-        private var instance: MessageReadinessManager = MessageReadinessManagerImpl(
-            CampaignRepository.instance(),
+        private val instance: MessageReadinessManager = MessageReadinessManager(
+            inAppMessaging = InAppMessaging.instance(),
+            campaignRepo = CampaignRepository.instance(),
+            configResponseRepo = ConfigResponseRepository.instance(),
+            hostAppInfoRepo = HostAppInfoRepository.instance(),
+            accountRepo = AccountRepository.instance(),
+            pingScheduler = MessageMixerPingScheduler.instance(),
+            viewUtil = ViewUtil,
         )
         internal val shouldRetry = AtomicBoolean(true)
         fun instance() = instance
-    }
-
-    @SuppressWarnings("TooManyFunctions", "LargeClass")
-    class MessageReadinessManagerImpl(private val campaignRepo: CampaignRepository) : MessageReadinessManager {
-        internal val queuedMessages = mutableListOf<String>()
-        private val queuedTooltips = mutableListOf<String>()
-
-        override fun addMessageToQueue(id: String) {
-            val message = campaignRepo.messages[id] ?: return
-            val queue = if (message.type == InAppMessageType.TOOLTIP.typeId) queuedTooltips else queuedMessages
-            synchronized(queue) { queue.add(id) }
-        }
-
-        override fun removeMessageFromQueue(id: String) {
-            val message = campaignRepo.messages[id] ?: return
-            val queue = if (message.type == InAppMessageType.TOOLTIP.typeId) queuedTooltips else queuedMessages
-            synchronized(queue) { queue.remove(id) }
-        }
-
-        override fun clearMessages() {
-            synchronized(queuedMessages) {
-                queuedMessages.clear()
-            }
-        }
-
-        @WorkerThread
-        @SuppressWarnings("LongMethod", "ComplexMethod", "ReturnCount")
-        override fun getNextDisplayMessage(): List<Message> {
-            shouldRetry.set(true)
-            val result = mutableListOf<Message>()
-            val hasCampaignsInQueue = queuedMessages.isNotEmpty()
-            // toList() to prevent ConcurrentModificationException
-            val queuedMessagesCopy = if (hasCampaignsInQueue) queuedMessages.toList() else queuedTooltips.toList()
-            for (messageId in queuedMessagesCopy) {
-                val message = campaignRepo.messages[messageId]
-                if (message == null) {
-                    InAppLogger(TAG).debug("Queued campaign $messageId does not exist in the repository anymore")
-                    continue
-                }
-
-                InAppLogger(TAG).debug("checking permission for message: %s", message.campaignId)
-
-                // First, check if this message should be displayed.
-                if (!shouldDisplayMessage(message)) {
-                    InAppLogger(TAG).debug("skipping message: %s", message.campaignId)
-                    // Skip to next message.
-                    continue
-                }
-
-                // If message is test message, no need to do more checks.
-                if (shouldPing(message, result)) break
-
-                // Multiple tooltips can be displayed, checked other from queue.
-                if (queuedTooltips.isNotEmpty()) {
-                    continue
-                } else if (result.isNotEmpty()) return result
-            }
-            return result
-        }
-
-        private fun shouldPing(message: Message, result: MutableList<Message>) = if (message.isTest) {
-            InAppLogger(TAG).debug("skipping test message: %s", message.campaignId)
-            result.add(message)
-            false
-        } else {
-            // Check message display permission with server.
-            val displayPermissionResponse = getMessagePermission(message)
-            // If server wants SDK to ping for updated messages, do a new ping request and break this loop.
-            when {
-                (displayPermissionResponse != null) && displayPermissionResponse.shouldPing -> {
-                    // reset current delay to initial
-                    MessageMixerPingScheduler.currDelay = RetryDelayUtil.INITIAL_BACKOFF_DELAY
-                    MessageMixerPingScheduler.instance().pingMessageMixerService(0)
-                    true
-                }
-                isMessagePermissibleToDisplay(displayPermissionResponse) -> {
-                    result.add(message)
-                    false
-                }
-                else -> false
-            }
-        }
-
-        @VisibleForTesting
-        override fun getDisplayPermissionRequest(message: Message): DisplayPermissionRequest {
-            return DisplayPermissionRequest(
-                campaignId = message.campaignId,
-                appVersion = HostAppInfoRepository.instance().getVersion(),
-                sdkVersion = BuildConfig.VERSION_NAME,
-                locale = HostAppInfoRepository.instance().getDeviceLocale(),
-                lastPingInMillis = CampaignRepository.instance().lastSyncMillis ?: 0,
-                userIdentifier = RuntimeUtil.getUserIdentifiers(),
-            )
-        }
-
-        @VisibleForTesting
-        override fun getDisplayCall(
-            displayPermissionUrl: String,
-            request: DisplayPermissionRequest,
-        ): Call<DisplayPermissionResponse> = RuntimeUtil.getRetrofit()
-            .create(MessageMixerRetrofitService::class.java)
-            .getDisplayPermissionService(
-                subscriptionId = HostAppInfoRepository.instance().getSubscriptionKey(),
-                accessToken = AccountRepository.instance().getAccessToken(),
-                url = displayPermissionUrl,
-                request = request,
-            )
-
-        /**
-         * This method checks if the message has infinite impressions, or has been displayed less
-         * than its max impressions, or has been opted out.
-         * Additional checks are performed depending on message type.
-         */
-        private fun shouldDisplayMessage(message: Message): Boolean {
-            val impressions = message.impressionsLeft ?: message.maxImpressions
-            val isOptOut = message.isOptedOut == true
-            val hasPassedBasicCheck = (message.areImpressionsInfinite || impressions > 0) && !isOptOut
-
-            return if (message.type == InAppMessageType.TOOLTIP.typeId) {
-                val shouldDisplayTooltip = hasPassedBasicCheck &&
-                    isTooltipTargetViewVisible(message) // if view where to attach tooltip is indeed visible
-                shouldDisplayTooltip
-            } else {
-                hasPassedBasicCheck
-            }
-        }
-
-        private fun isTooltipTargetViewVisible(message: Message): Boolean {
-            val activity = InAppMessaging.instance().getRegisteredActivity()
-            val id = message.getTooltipConfig()?.id
-
-            if (activity != null && id != null) {
-                ResourceUtils.findViewByName<View>(activity, id)?.let {
-                    return it.isVisible()
-                }
-            }
-            return false
-        }
-
-        /**
-         * This method returns if message is permissible to be displayed according to the message.
-         * display permission response parameter.
-         */
-        private fun isMessagePermissibleToDisplay(response: DisplayPermissionResponse?): Boolean =
-            response != null && response.display
-
-        /**
-         * This method returns display message permission (from server).
-         */
-        private fun getMessagePermission(message: Message): DisplayPermissionResponse? {
-            // Prepare request data.
-            val displayPermissionUrl: String = ConfigResponseRepository.instance().getDisplayPermissionEndpoint()
-            if (displayPermissionUrl.isEmpty()) return null
-
-            // Prepare network request.
-            val request = getDisplayPermissionRequest(message)
-            val permissionCall: Call<DisplayPermissionResponse> =
-                getDisplayCall(displayPermissionUrl, request)
-            AccountRepository.instance().logWarningForUserInfo(TAG)
-            return executeDisplayRequest(permissionCall)
-        }
-
-        @SuppressWarnings("TooGenericExceptionCaught")
-        private fun executeDisplayRequest(call: Call<DisplayPermissionResponse>): DisplayPermissionResponse? {
-            return try {
-                val response = call.execute()
-                handleResponse(response, call.clone())
-            } catch (e: Exception) {
-                checkAndRetry(call.clone()) {
-                    InAppLogger(DISP_TAG).error(e.message)
-                    InAppMessaging.errorCallback?.let {
-                        it(InAppMessagingException("In-App Messaging display permission request failed", e))
-                    }
-                }
-            }
-        }
-
-        private fun handleResponse(
-            response: Response<DisplayPermissionResponse>,
-            callClone: Call<DisplayPermissionResponse>,
-        ): DisplayPermissionResponse? {
-            return when {
-                response.isSuccessful -> {
-                    InAppLogger(DISP_TAG).debug(
-                        "display: %b performPing: %b", response.body()?.display, response.body()?.shouldPing,
-                    )
-                    response.body()
-                }
-                response.code() >= HttpURLConnection.HTTP_INTERNAL_ERROR -> checkAndRetry(callClone) {
-                    WorkerUtils.logRequestError(DISP_TAG, response.code(), response.errorBody()?.string())
-                }
-                else -> {
-                    WorkerUtils.logRequestError(DISP_TAG, response.code(), response.errorBody()?.string())
-                    null
-                }
-            }
-        }
-
-        private fun checkAndRetry(
-            call: Call<DisplayPermissionResponse>,
-            errorHandling: () -> Unit,
-        ): DisplayPermissionResponse? {
-            return if (shouldRetry.getAndSet(false)) {
-                executeDisplayRequest(call)
-            } else {
-                errorHandling.invoke()
-                null
-            }
-        }
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -70,7 +70,6 @@ internal interface ReadinessManager {
     "LongParameterList",
 )
 internal class MessageReadinessManager(
-    val inAppMessaging: InAppMessaging,
     val campaignRepo: CampaignRepository,
     val configResponseRepo: ConfigResponseRepository,
     val hostAppInfoRepo: HostAppInfoRepository,
@@ -202,7 +201,7 @@ internal class MessageReadinessManager(
     }
 
     private fun isTooltipTargetViewVisible(message: Message): Boolean {
-        val activity = inAppMessaging.getRegisteredActivity()
+        val activity = hostAppInfoRepo.getRegisteredActivity()
         val id = message.getTooltipConfig()?.id
 
         if (activity != null && id != null) {
@@ -286,7 +285,6 @@ internal class MessageReadinessManager(
         private const val TAG = "IAM_MsgReadinessManager"
         private const val DISP_TAG = "IAM_DisplayPermission"
         private val instance: MessageReadinessManager = MessageReadinessManager(
-            inAppMessaging = InAppMessaging.instance(),
             campaignRepo = CampaignRepository.instance(),
             configResponseRepo = ConfigResponseRepository.instance(),
             hostAppInfoRepo = HostAppInfoRepository.instance(),

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -99,6 +99,7 @@ internal object Initializer {
         )
 
         // Store hostAppInfo in repository.
+        HostAppInfoRepository.instance().setContext(context)
         HostAppInfoRepository.instance().addHostInfo(hostAppInfo)
 
         initializePicassoInstance(context)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -102,8 +102,6 @@ internal object Initializer {
         HostAppInfoRepository.instance().addHostInfo(hostAppInfo)
 
         initializePicassoInstance(context)
-
-        InAppLogger(TAG).debug(Gson().toJson(hostAppInfo))
     }
 
     /**

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -95,11 +95,10 @@ internal object Initializer {
         val hostAppInfo = HostAppInfo(
             packageName = getHostAppPackageName(context), deviceId = getDeviceId(context, sharedUtil),
             version = getHostAppVersion(context), subscriptionKey = subscriptionKey, locale = getLocale(context),
-            configUrl = configUrl, isTooltipFeatureEnabled = enableTooltipFeature,
+            configUrl = configUrl, isTooltipFeatureEnabled = enableTooltipFeature, context = context,
         )
 
         // Store hostAppInfo in repository.
-        HostAppInfoRepository.instance().setContext(context)
         HostAppInfoRepository.instance().addHostInfo(hostAppInfo)
 
         initializePicassoInstance(context)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtil.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
+import android.app.Activity
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Point
@@ -14,6 +15,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.PositionType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.SlideFromDirectionType
 import com.rakuten.tech.mobile.inappmessaging.runtime.extensions.getRectLocationOnContainer
+import com.rakuten.tech.mobile.inappmessaging.runtime.extensions.isVisible
 import com.rakuten.tech.mobile.inappmessaging.runtime.view.InAppMessagingTooltipView.Companion.TRI_SIZE
 
 /**
@@ -115,5 +117,10 @@ internal object ViewUtil {
             currView = currView.parent
         }
         return null
+    }
+
+    fun isViewByNameVisible(activity: Activity, name: String, resourceUtil: ResourceUtils? = null): Boolean {
+        val view = (resourceUtil ?: ResourceUtils).findViewByName<View>(activity, name)
+        return view?.isVisible() ?: false
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtil.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtil.kt
@@ -121,6 +121,6 @@ internal object ViewUtil {
 
     fun isViewByNameVisible(activity: Activity, name: String, resourceUtil: ResourceUtils? = null): Boolean {
         val view = (resourceUtil ?: ResourceUtils).findViewByName<View>(activity, name)
-        return view?.isVisible() ?: false
+        return view?.isVisible() == true
     }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListener.kt
@@ -8,10 +8,10 @@ import android.widget.CheckBox
 import android.widget.Magnifier
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.coroutine.MessageActionsCoroutine
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.InAppMessageType
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.BuildVersionChecker
@@ -31,7 +31,7 @@ internal class InAppMessageViewListener(
     private val displayManager: DisplayManager = DisplayManager.instance(),
     private val buildChecker: BuildVersionChecker = BuildVersionChecker.instance(),
     private val eventScheduler: EventMessageReconciliationScheduler = EventMessageReconciliationScheduler.instance(),
-    private val inApp: InAppMessaging = InAppMessaging.instance(),
+    private val hostAppInfoRepo: HostAppInfoRepository = HostAppInfoRepository.instance(),
 ) :
     View.OnTouchListener, View.OnClickListener, View.OnKeyListener {
 
@@ -98,7 +98,7 @@ internal class InAppMessageViewListener(
     ) {
         CoroutineScope(mainDispatcher).launch {
             displayManager.removeMessage(
-                inApp.getRegisteredActivity(),
+                hostAppInfoRepo.getRegisteredActivity(),
                 id = if (message.type == InAppMessageType.TOOLTIP.typeId) message.campaignId else null,
             )
             withContext(dispatcher) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessagingTooltipView.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessagingTooltipView.kt
@@ -23,9 +23,9 @@ import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.PositionType
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.extensions.hide
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
@@ -107,7 +107,7 @@ internal class InAppMessagingTooltipView(
 
     /** The anchor view of this tooltip. */
     private fun findAnchorView(): View? {
-        val activity = InAppMessaging.instance().getRegisteredActivity()
+        val activity = HostAppInfoRepository.instance().getRegisteredActivity()
         if (activity != null) {
             viewId?.let { return ResourceUtils.findViewByName(activity, it) }
         }
@@ -339,7 +339,7 @@ internal class InAppMessagingTooltipView(
 
     /** Sets the top-left position of this tooltip. */
     private fun setPosition() {
-        val activity = InAppMessaging.instance().getRegisteredActivity() ?: return
+        val activity = HostAppInfoRepository.instance().getRegisteredActivity() ?: return
         findAnchorView()?.let { anchorView ->
             val container = ViewUtil.getScrollView(anchorView) ?: activity.findViewById(android.R.id.content)
             val tPosition = ViewUtil.getTooltipPosition(

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ConfigScheduler.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ConfigScheduler.kt
@@ -4,6 +4,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RetryDelayUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.WorkManagerUtil
@@ -28,7 +29,7 @@ internal interface ConfigScheduler {
     private class ConfigSchedulerImpl : ConfigScheduler {
         override fun startConfig(delay: Long, workManager: WorkManager?) {
             try {
-                val context = InAppMessaging.instance().getHostAppContext()
+                val context = HostAppInfoRepository.instance().getContext()
                 context?.let { ctx ->
                     val manager = workManager ?: WorkManager.getInstance(ctx)
                     manager.beginUniqueWork(

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationScheduler.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/EventMessageReconciliationScheduler.kt
@@ -4,6 +4,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.workmanager.workers.MessageEventReconciliationWorker
 import java.util.concurrent.TimeUnit
@@ -37,7 +38,7 @@ internal interface EventMessageReconciliationScheduler {
                 .build()
 
             try {
-                val context = InAppMessaging.instance().getHostAppContext()
+                val context = HostAppInfoRepository.instance().getContext()
                 context?.let { ctx ->
                     val manager = workManager ?: WorkManager.getInstance(ctx)
                     manager.beginUniqueWork(

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionScheduler.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionScheduler.kt
@@ -5,6 +5,7 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.google.gson.Gson
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.requests.ImpressionRequest
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.WorkManagerUtil
@@ -22,7 +23,7 @@ internal class ImpressionScheduler {
     fun startImpressionWorker(impressionRequest: ImpressionRequest, workManager: WorkManager? = null) {
         // Enqueue unique work request in the background.
         try {
-            val context = InAppMessaging.instance().getHostAppContext()
+            val context = HostAppInfoRepository.instance().getContext()
             context?.let { ctx ->
                 val manager = workManager ?: WorkManager.getInstance(ctx)
                 manager.enqueue(createWorkRequest(impressionRequest))

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/MessageMixerPingScheduler.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/MessageMixerPingScheduler.kt
@@ -5,6 +5,7 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.RetryDelayUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.WorkManagerUtil
@@ -64,7 +65,7 @@ internal interface MessageMixerPingScheduler {
 
         private fun enqueueRequest(workManager: WorkManager?, periodicMessageMixerFetch: OneTimeWorkRequest) {
             try {
-                val context = InAppMessaging.instance().getHostAppContext()
+                val context = HostAppInfoRepository.instance().getContext()
                 context?.let { ctx ->
                     val manager = workManager ?: WorkManager.getInstance(ctx)
                     manager.enqueueUniqueWork(

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/DisplayMessageWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkerParameters
 import androidx.work.WorkManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.ImageUtil
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
@@ -47,7 +48,7 @@ internal class DisplayMessageWorker(
     private fun prepareNextMessage() {
         // Retrieving the next ready message, and its display permission been checked.
         val messages = messageReadinessManager.getNextDisplayMessage()
-        val hostActivity = InAppMessaging.instance().getRegisteredActivity()
+        val hostActivity = HostAppInfoRepository.instance().getRegisteredActivity()
         if (hostActivity != null) {
             for (message in messages) {
                 val imageUrl = message.messagePayload.resource.imageUrl
@@ -118,7 +119,7 @@ internal class DisplayMessageWorker(
          * This method enqueues work in to this service.
          */
         fun enqueueWork() {
-            InAppMessaging.instance().getHostAppContext()?.let { ctx ->
+            HostAppInfoRepository.instance().getContext()?.let { ctx ->
                 val displayRequest = OneTimeWorkRequest.Builder(DisplayMessageWorker::class.java)
                     .setConstraints(WorkManagerUtil.getNetworkConnectedConstraint())
                     .addTag(DISPLAY_WORKER)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingSpec.kt
@@ -87,7 +87,6 @@ open class InAppMessagingSpec : BaseTest() {
         ConfigResponseRepository.instance().addConfigResponse(configResponseData)
 
         return InApp(
-            context = ApplicationProvider.getApplicationContext(),
             isDebugLogging = false,
             displayManager = displayManager,
             eventsManager = eventsManager,
@@ -120,9 +119,9 @@ class InAppMessagingBasicSpec : InAppMessagingSpec() {
         initializeInstance()
 
         InAppMessaging.instance().registerMessageDisplayActivity(activity)
-        InAppMessaging.instance().getRegisteredActivity() shouldBeEqualTo activity
+        HostAppInfoRepository.instance().getRegisteredActivity() shouldBeEqualTo activity
         InAppMessaging.instance().unregisterMessageDisplayActivity()
-        InAppMessaging.instance().getRegisteredActivity().shouldBeNull()
+        HostAppInfoRepository.instance().getRegisteredActivity().shouldBeNull()
     }
 
     @SuppressWarnings("SwallowedException")
@@ -525,18 +524,6 @@ class InAppMessagingUnInitSpec : InAppMessagingSpec() {
         InAppMessaging.instance().isLocalCachingEnabled().shouldBeFalse()
         InAppMessaging.instance().trackPushPrimer(arrayOf(""), intArrayOf(1))
         InAppMessaging.instance().onPushPrimer.shouldBeNull()
-    }
-
-    @Test
-    fun `should return null activity using uninitialized instance`() {
-        InAppMessaging.setNotConfiguredInstance()
-        InAppMessaging.instance().getRegisteredActivity().shouldBeNull()
-    }
-
-    @Test
-    fun `should return null context using uninitialized instance`() {
-        InAppMessaging.setNotConfiguredInstance()
-        InAppMessaging.instance().getHostAppContext() shouldBeEqualTo null
     }
 }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
@@ -109,7 +109,6 @@ internal class MessageActionsCoroutineSpec(
         updatedMessage.impressionsLeft shouldBeEqualTo currImpressions - 1
         updatedMessage.isOptedOut shouldBeEqualTo isOpt
 
-        (readinessManager as MessageReadinessManager.MessageReadinessManagerImpl).queuedMessages.shouldBeEmpty()
         readinessManager.clearMessages()
     }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/coroutine/MessageActionsCoroutineSpec.kt
@@ -16,6 +16,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.enums.ImpressionType
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.CampaignRepository
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
@@ -70,14 +71,14 @@ internal class MessageActionsCoroutineSpec(
 
     @Test
     fun `should return false when message is null`() {
-        DisplayManager.instance().removeMessage(InAppMessaging.instance().getRegisteredActivity())
+        DisplayManager.instance().removeMessage(HostAppInfoRepository.instance().getRegisteredActivity())
         val result = MessageActionsCoroutine().executeTask(null, resourceId, isOpt)
         result.shouldBeFalse()
     }
 
     @Test
     fun `should return false when campaign id is empty`() {
-        DisplayManager.instance().removeMessage(InAppMessaging.instance().getRegisteredActivity())
+        DisplayManager.instance().removeMessage(HostAppInfoRepository.instance().getRegisteredActivity())
         val result = MessageActionsCoroutine().executeTask(
             TestDataHelper.createDummyMessage(campaignId = ""), resourceId, isOpt,
         )
@@ -87,7 +88,7 @@ internal class MessageActionsCoroutineSpec(
     @Test
     fun `should return true when campaign is valid`() {
         val message = if (isTooltip) TooltipHelper.createMessage() else TestDataHelper.createDummyMessage()
-        DisplayManager.instance().removeMessage(InAppMessaging.instance().getRegisteredActivity())
+        DisplayManager.instance().removeMessage(HostAppInfoRepository.instance().getRegisteredActivity())
         val result = MessageActionsCoroutine().executeTask(message, resourceId, isOpt)
         result.shouldBeTrue()
     }
@@ -101,7 +102,7 @@ internal class MessageActionsCoroutineSpec(
         readinessManager.clearMessages()
         readinessManager.addMessageToQueue(message.campaignId)
         val currImpressions = message.impressionsLeft!!
-        DisplayManager.instance().removeMessage(InAppMessaging.instance().getRegisteredActivity())
+        DisplayManager.instance().removeMessage(HostAppInfoRepository.instance().getRegisteredActivity())
         val result = MessageActionsCoroutine().executeTask(message, resourceId, isOpt)
         val updatedMessage = CampaignRepository.instance().messages.values.first()
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepositorySpec.kt
@@ -1,29 +1,33 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories
 
+import android.app.Activity
+import androidx.test.core.app.ApplicationProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessagingTestConstants
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
-import org.amshove.kluent.shouldBeEmpty
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.*
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
 import java.util.Locale
 
 /**
  * Test class for HostAppInfoRepository class
  */
+@RunWith(RobolectricTestRunner::class)
 class HostAppInfoRepositorySpec : BaseTest() {
 
     private val testAppInfo = HostAppInfo(
         InAppMessagingTestConstants.APP_ID, InAppMessagingTestConstants.DEVICE_ID,
         InAppMessagingTestConstants.APP_VERSION, InAppMessagingTestConstants.SUB_KEY,
         InAppMessagingTestConstants.LOCALE, isTooltipFeatureEnabled = true,
+        context = ApplicationProvider.getApplicationContext(),
     )
 
     @Before
@@ -49,6 +53,7 @@ class HostAppInfoRepositorySpec : BaseTest() {
         HostAppInfoRepository.instance()
             .getSubscriptionKey() shouldBeEqualTo InAppMessagingTestConstants.SUB_KEY
         HostAppInfoRepository.instance().getDeviceId() shouldBeEqualTo InAppMessagingTestConstants.DEVICE_ID
+        HostAppInfoRepository.instance().getContext() shouldBeEqualTo ApplicationProvider.getApplicationContext()
     }
 
     @Test
@@ -148,5 +153,19 @@ class HostAppInfoRepositorySpec : BaseTest() {
     fun `should enable tooltip feature`() {
         HostAppInfoRepository.instance().addHostInfo(testAppInfo.copy(isTooltipFeatureEnabled = true))
         HostAppInfoRepository.instance().isTooltipFeatureEnabled().shouldBeTrue()
+    }
+
+    @Test
+    fun `should return valid activity`() {
+        val activity = mock(Activity::class.java)
+
+        HostAppInfoRepository.instance().registerActivity(activity)
+        HostAppInfoRepository.instance().getRegisteredActivity().shouldBeEqualTo(activity)
+    }
+
+    @Test
+    fun `should return null activity`() {
+        HostAppInfoRepository.instance().registerActivity(null)
+        HostAppInfoRepository.instance().getRegisteredActivity().shouldBeNull()
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
@@ -35,10 +35,10 @@ import java.util.*
 import kotlin.collections.ArrayList
 
 /**
- * Test class for MessageMessageReadinessManager.
+ * Test class for MessageReadinessManager.
  */
 @RunWith(RobolectricTestRunner::class)
-open class MessageMessageReadinessManagerSpec : BaseTest() {
+open class MessageReadinessManagerSpec : BaseTest() {
     private var configResponseData = mock(ConfigResponseData::class.java)
     private var configResponseEndpoints = mock(ConfigResponseEndpoints::class.java)
 
@@ -235,7 +235,7 @@ open class MessageMessageReadinessManagerSpec : BaseTest() {
     }
 }
 
-class MessageMessageReadinessManagerRequestSpec : BaseTest() {
+class MessageReadinessManagerRequestSpec : BaseTest() {
     private val server = MockWebServer()
     private var data = mock(ConfigResponseData::class.java)
     private var endpoint = mock(ConfigResponseEndpoints::class.java)
@@ -356,7 +356,7 @@ class MessageMessageReadinessManagerRequestSpec : BaseTest() {
     }
 }
 
-class MessageMessageReadinessManagerCallSpec : MessageMessageReadinessManagerSpec() {
+class MessageReadinessManagerCallSpec : MessageReadinessManagerSpec() {
     private var mockRequest = mock(DisplayPermissionRequest::class.java)
 
     @Test
@@ -498,7 +498,7 @@ class MessageReadinessTooltipSpec {
     }
 
     @Test
-    fun `should get display call`() {
+    fun `should get display call for tooltip`() {
         `when`(manager.hostAppInfoRepo.getSubscriptionKey()).thenReturn("test-key")
         `when`(manager.accountRepo.getAccessToken()).thenReturn("test-token")
         val request = manager.getDisplayPermissionRequest(testTooltip)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManagerSpec.kt
@@ -386,7 +386,6 @@ class MessageReadinessManagerCallSpec : MessageReadinessManagerSpec() {
 @RunWith(RobolectricTestRunner::class)
 class MessageReadinessTooltipSpec {
     private val manager = MessageReadinessManager(
-        inAppMessaging = mock(InAppMessaging::class.java),
         campaignRepo = mock(CampaignRepository::class.java),
         configResponseRepo = mock(ConfigResponseRepository::class.java),
         hostAppInfoRepo = mock(HostAppInfoRepository::class.java),
@@ -401,8 +400,8 @@ class MessageReadinessTooltipSpec {
     @Before
     fun setup() {
         `when`(manager.campaignRepo.messages).thenReturn(linkedMapOf(testTooltip.campaignId to testTooltip))
-        `when`(manager.inAppMessaging.getRegisteredActivity()).thenReturn(mockActivity)
-        `when`(manager.inAppMessaging.getHostAppContext()).thenReturn(mock(Context::class.java))
+        `when`(manager.hostAppInfoRepo.getRegisteredActivity()).thenReturn(mockActivity)
+        `when`(manager.hostAppInfoRepo.getContext()).thenReturn(mock(Context::class.java))
         `when`(manager.configResponseRepo.getDisplayPermissionEndpoint()).thenReturn("http://sample")
     }
 
@@ -473,7 +472,7 @@ class MessageReadinessTooltipSpec {
 
     @Test
     fun `should not return tooltip if activity becomes null when calling getNextDisplayMessage()`() {
-        `when`(manager.inAppMessaging.getRegisteredActivity()).thenReturn(null)
+        `when`(manager.hostAppInfoRepo.getRegisteredActivity()).thenReturn(null)
         manager.addMessageToQueue(testTooltip.campaignId)
 
         manager.getNextDisplayMessage().shouldNotContain(testTooltip)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtilSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/ViewUtilSpec.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.inappmessaging.runtime.utils
 
+import android.app.Activity
 import android.content.Context
 import android.content.res.Resources
 import android.view.View
@@ -112,6 +113,15 @@ class ViewUtilSpec : BaseTest() {
         `when`(mockView.parent).thenReturn(mockView2)
         `when`(mockView2.parent).thenReturn(mockScrollView)
         ViewUtil.getScrollView(mockView).shouldNotBeNull()
+    }
+
+    @Test
+    fun `should return false when calling isViewByNameVisible`() {
+        val mockResourceUtil = mock(ResourceUtils::class.java)
+        val mockActivity = mock(Activity::class.java)
+        `when`(mockResourceUtil.findViewByName<View>(mockActivity, "viewName"))
+            .thenReturn(mock(View::class.java))
+        ViewUtil.isViewByNameVisible(mockActivity, "viewName", mockResourceUtil).shouldBeFalse()
     }
 }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListenerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/view/InAppMessageViewListenerSpec.kt
@@ -8,9 +8,9 @@ import android.widget.CheckBox
 import android.widget.Magnifier
 import com.nhaarman.mockitokotlin2.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.R
 import com.rakuten.tech.mobile.inappmessaging.runtime.coroutine.MessageActionsCoroutine
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.DisplaySettings
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.Message
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.responses.ping.MessagePayload
@@ -36,7 +36,7 @@ open class InAppMessageViewListenerSpec : BaseTest() {
     internal val mockCoroutine = Mockito.mock(MessageActionsCoroutine::class.java)
     internal val mockEventScheduler = Mockito.mock(EventMessageReconciliationScheduler::class.java)
     internal val mockActivity = Mockito.mock(Activity::class.java)
-    internal val mockInApp = Mockito.mock(InAppMessaging::class.java)
+    internal val mockHostAppInfoRepo = Mockito.mock(HostAppInfoRepository::class.java)
 
     @Before
     override fun setup() {
@@ -72,7 +72,7 @@ class InAppMessageViewListenerOnClickSpec : InAppMessageViewListenerSpec() {
         val mockView = Mockito.mock(CheckBox::class.java)
         `when`(mockView.id).thenReturn(R.id.message_close_button)
         `when`(mockCoroutine.executeTask(message, R.id.message_close_button, false)).thenReturn(true)
-        `when`(mockInApp.getRegisteredActivity()).thenReturn(mockActivity)
+        `when`(mockHostAppInfoRepo.getRegisteredActivity()).thenReturn(mockActivity)
 
         listener.onClick(mockView)
     }
@@ -109,7 +109,7 @@ class InAppMessageViewListenerOnClickSpec : InAppMessageViewListenerSpec() {
         messageCoroutine = mockCoroutine,
         displayManager = mockDisplayManager,
         eventScheduler = mockEventScheduler,
-        inApp = mockInApp,
+        hostAppInfoRepo = mockHostAppInfoRepo,
     )
 }
 
@@ -434,13 +434,13 @@ class InAppMessageViewListenerOnKeySpec : InAppMessageViewListenerSpec() {
             messageCoroutine = mockCoroutine,
             displayManager = mockDisplayManager,
             eventScheduler = mockEventScheduler,
-            inApp = mockInApp,
+            hostAppInfoRepo = mockHostAppInfoRepo,
         )
 
         `when`(keyEvent.action).thenReturn(KeyEvent.ACTION_UP)
         `when`(mockView.id).thenReturn(R.id.message_close_button)
         `when`(mockCoroutine.executeTask(message, MessageActionsCoroutine.BACK_BUTTON, false)).thenReturn(false)
-        `when`(mockInApp.getRegisteredActivity()).thenReturn(mockActivity)
+        `when`(mockHostAppInfoRepo.getRegisteredActivity()).thenReturn(mockActivity)
 
         listener.onKey(mockView, KeyEvent.KEYCODE_BACK, keyEvent).shouldBeTrue()
 
@@ -481,6 +481,6 @@ class InAppMessageViewListenerHandleSpec : InAppMessageViewListenerSpec() {
         messageCoroutine = mockCoroutine,
         displayManager = mockDisplayManager,
         eventScheduler = mockEventScheduler,
-        inApp = mockInApp,
+        hostAppInfoRepo = mockHostAppInfoRepo,
     )
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionSchedulerSpec.kt
@@ -78,16 +78,6 @@ class ImpressionSchedulerSpec : BaseTest() {
         setupImpressionScheduler(mockWorkManager)
     }
 
-    @Test
-    fun `should not throw exception with valid workmanager but null context`() {
-        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
-        setupImpressionScheduler()
-        WorkManager.getInstance(ApplicationProvider.getApplicationContext())
-            .getWorkInfosByTag(IMPRESSION_WORKER_NAME)
-            .get()
-            .shouldBeEmpty()
-    }
-
     private fun setupImpressionScheduler(mockManager: WorkManager? = null) {
         val impressionTypes = mutableListOf(ImpressionType.CLICK_CONTENT)
         // Assemble ImpressionRequest object.


### PR DESCRIPTION
# Description
Refactored to improve the testability of MessageReadinessManager by constructor DI, and added tests.
Changelog will be updated altogether in a separate PR.

## Links
SDKCF-6458

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
