### PR TITLE
refactor: improve coverage for MessageEventReconciliationUtil (SDKCF-6398)

### DIFF
--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageEventReconciliationWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageEventReconciliationWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.rakuten.tech.mobile.inappmessaging.runtime.BuildConfig
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.CampaignRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.DisplayManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.manager.MessageReadinessManager
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppLogger
@@ -30,7 +31,11 @@ internal class MessageEventReconciliationWorker(
      */
     constructor(context: Context, workerParams: WorkerParameters) :
         this(
-            context, workerParams, EventMatchingUtil.instance(), MessageEventReconciliationUtil.instance(),
+            context, workerParams, EventMatchingUtil.instance(),
+            MessageEventReconciliationUtil(
+                campaignRepo = CampaignRepository.instance(),
+                eventMatchingUtil = EventMatchingUtil.instance(),
+            ),
             MessageReadinessManager.instance(),
         )
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageEventReconciliationWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageEventReconciliationWorkerSpec.kt
@@ -55,7 +55,10 @@ class MessageEventReconciliationWorkerSpec : BaseTest() {
             ApplicationProvider.getApplicationContext(),
             workerParameters,
             EventMatchingUtil.instance(),
-            MessageEventReconciliationUtil.instance(),
+            MessageEventReconciliationUtil(
+                campaignRepo = CampaignRepository.instance(),
+                eventMatchingUtil = EventMatchingUtil.instance(),
+            ),
             MessageReadinessManager.instance(),
         )
         CampaignRepository.instance().syncWith(listOf(message, notTestMessage), 0)


### PR DESCRIPTION
# Description
Refactored to improve the testability of MessageEventReconciliationUtil by constructor DI, and added tests.
Changelog will be updated altogether in a separate PR.

## Links
SDKCF-6398

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
