### PR TITLE
fix: impression is not incremented when tooltip campaign is displayed (SDKCF-6547)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -493,6 +493,7 @@ Documents targeting Product Managers:
   - MessageReadinessManager (SDKCF-6458)
   - TriggerAttributesValidator (SDKCF-6399)
   - BuildVersionChecker (SDKCF-6513)
+* SDKCF-6547: Fixed impression is not incremented when tooltip campaign is displayed.
 
 ### 7.4.0 (2023-04-24)
 * SDKCF-6321: Updated detekt version to `1.22.0`.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
@@ -94,7 +94,13 @@ internal class DisplayMessageRunnable(
         val toolTipView = hostActivity.layoutInflater.inflate(R.layout.in_app_message_tooltip, null)
             as InAppMessagingTooltipView
         toolTipView.populateViewData(message)
-        message.getTooltipConfig()?.let { displayTooltip(it, toolTipView) }
+        message.getTooltipConfig()?.let {
+            displayTooltip(it, toolTipView)
+            ImpressionManager.sendImpressionEvent(
+                message.campaignId,
+                listOf(Impression(ImpressionType.IMPRESSION, Date().time)),
+                impressionTypeOnly = true,
+            )}
     }
 
     private fun displayTooltip(tooltip: Tooltip, toolTipView: InAppMessagingTooltipView) {

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/runnable/DisplayMessageRunnable.kt
@@ -94,40 +94,47 @@ internal class DisplayMessageRunnable(
         val toolTipView = hostActivity.layoutInflater.inflate(R.layout.in_app_message_tooltip, null)
             as InAppMessagingTooltipView
         toolTipView.populateViewData(message)
-        message.getTooltipConfig()?.let {
-            displayTooltip(it, toolTipView)
-            ImpressionManager.sendImpressionEvent(
-                message.campaignId,
-                listOf(Impression(ImpressionType.IMPRESSION, Date().time)),
-                impressionTypeOnly = true,
-            )}
+        message.getTooltipConfig()?.let { config ->
+            if (displayTooltip(config, toolTipView)) {
+                ImpressionManager.sendImpressionEvent(
+                    message.campaignId,
+                    listOf(Impression(ImpressionType.IMPRESSION, Date().time)),
+                    impressionTypeOnly = true,
+                )
+            }
+        }
     }
 
-    private fun displayTooltip(tooltip: Tooltip, toolTipView: InAppMessagingTooltipView) {
+    private fun displayTooltip(tooltip: Tooltip, toolTipView: InAppMessagingTooltipView): Boolean {
+        var isTooltipAdded = false
         ResourceUtils.findViewByName<View>(hostActivity, tooltip.id)?.let { target ->
             val scroll = ViewUtil.getScrollView(target)
-            if (scroll != null) {
+            isTooltipAdded = if (scroll != null) {
                 displayInScrollView(scroll, toolTipView)
             } else {
                 val params = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
                 )
                 hostActivity.addContentView(toolTipView, params)
+                true
             }
             if (tooltip.autoDisappear != null && tooltip.autoDisappear > 0) {
                 displayManager.removeMessage(hostActivity, delay = tooltip.autoDisappear, id = message.campaignId)
             }
         }
+        return isTooltipAdded
     }
 
     /** Adds the tooltip to the anchor view's parent scroll view. */
-    private fun displayInScrollView(scroll: ViewGroup, toolTipView: InAppMessagingTooltipView) {
-        (scroll.getChildAt(0) as? ViewGroup)?.addView(
+    private fun displayInScrollView(scroll: ViewGroup, toolTipView: InAppMessagingTooltipView): Boolean {
+        val anchor = scroll.getChildAt(0) as? ViewGroup
+        anchor?.addView(
             toolTipView,
             ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
             ),
         )
+        return anchor != null
     }
 
     private fun shouldNotDisplay(messageType: InAppMessageType?): Boolean {


### PR DESCRIPTION
# Description
Added missing impressions handling for tooltip.

## Links
SDKCF-6547

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
