### PR TITLE
feat: [RMC] add sending of `rmcSdkVersion` in IAM requests (SDKCF-6708)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -485,7 +485,6 @@ Documents targeting Product Managers:
 
 ### 7.5.0 (In-Progress)
 * SDKCF-6575: Added sending of device Id in all IAM requests.
-* SDKCF-6711: Added support for RMC SDK configuration.
 * Improved the following classes to increase code coverage:
   - InAppMessagingConstants (SDKCF-6497)
   - InAppMessageSlideUpView (SDKCF-6478)
@@ -504,6 +503,9 @@ Documents targeting Product Managers:
   - Dependency Check to `8.2.1`
 * SDKCF-6547: Fixed impression is not incremented when tooltip campaign is displayed.
 * SDKCF-6518: Fixed and suppressed some SonarCloud code smells.
+* Updates for RMC SDK:
+  - Prevent calling `configure()` when RMC SDK is integrated (SDKCF-6711)
+  - Added sending of `rmcSdkVersion` in IAM requests (SDKCF-6708)
 
 ### 7.4.0 (2023-04-24)
 * SDKCF-6321: Updated detekt version to `1.22.0`.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/RmcHelper.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/RmcHelper.kt
@@ -27,6 +27,7 @@ internal object RmcHelper {
      * @return the RMC SDK version if integrated by app, otherwise null.
      */
     @SuppressWarnings("TooGenericExceptionCaught")
+    @JvmStatic
     fun getRmcVersion(context: Context): String? {
         return try {
             context.getString(

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/HostAppInfo.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/models/HostAppInfo.kt
@@ -15,4 +15,5 @@ internal data class HostAppInfo(
     internal val configUrl: String? = null,
     internal val isTooltipFeatureEnabled: Boolean? = null,
     internal val context: Context? = null,
+    internal val rmcSdkVersion: String? = null,
 )

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepository.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepository.kt
@@ -36,6 +36,11 @@ internal interface HostAppInfoRepository {
     fun getVersion(): String
 
     /**
+     * This method returns host app's RMC SDK version or null if not integrated.
+     */
+    fun getRmcSdkVersion(): String?
+
+    /**
      * This method returns host app's package name or empty string if not set.
      */
     fun getPackageName(): String
@@ -124,6 +129,8 @@ internal interface HostAppInfoRepository {
         }
 
         override fun getVersion(): String = hostAppInfo?.version.orEmpty()
+
+        override fun getRmcSdkVersion(): String? = hostAppInfo?.rmcSdkVersion
 
         override fun getPackageName(): String = hostAppInfo?.packageName.orEmpty()
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilder.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilder.kt
@@ -15,16 +15,13 @@ internal data class ConfigQueryParamsBuilder(
 
     private val platform = InAppMessagingConstants.ANDROID_PLATFORM_ENUM
 
-    private val _queryParams = mutableMapOf<String, Any?>(
+    val queryParams = mapOf<String, Any?>(
         "platform" to platform,
         "appId" to appId,
         "sdkVersion" to sdkVersion,
         "appVersion" to appVersion,
         "locale" to locale.orEmpty(),
+        "rmcSdkVersion" to rmcSdkVersion,
     )
-    val queryParams = if (rmcSdkVersion == null) {
-        _queryParams
-    } else {
-        _queryParams.apply { put("rmcSdkVersion", rmcSdkVersion) }
-    }
+        get() = field.filterValues { it != null }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilder.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilder.kt
@@ -10,15 +10,21 @@ internal data class ConfigQueryParamsBuilder(
     private val locale: String? = null,
     private val appVersion: String? = null,
     private val sdkVersion: String? = null,
+    private val rmcSdkVersion: String? = null,
 ) {
 
     private val platform = InAppMessagingConstants.ANDROID_PLATFORM_ENUM
 
-    val queryParams = mutableMapOf<String, Any?>(
+    private val _queryParams = mutableMapOf<String, Any?>(
         "platform" to platform,
         "appId" to appId,
         "sdkVersion" to sdkVersion,
         "appVersion" to appVersion,
         "locale" to locale.orEmpty(),
     )
+    val queryParams = if (rmcSdkVersion == null) {
+        _queryParams
+    } else {
+        _queryParams.apply { put("rmcSdkVersion", rmcSdkVersion) }
+    }
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequest.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequest.kt
@@ -13,6 +13,7 @@ internal data class DisplayPermissionRequest(
     val locale: String?,
     val lastPingInMillis: Long,
     val userIdentifier: List<UserIdentifier>,
+    val rmcSdkVersion: String?,
 ) {
     private val platform: Int = InAppMessagingConstants.ANDROID_PLATFORM_ENUM
 }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequest.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequest.kt
@@ -13,6 +13,7 @@ internal data class ImpressionRequest(
     private val sdkVersion: String?,
     private val userIdentifiers: List<UserIdentifier>,
     val impressions: List<Impression>,
+    val rmcSdkVersion: String?,
 )
 
 internal data class Impression(

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequest.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequest.kt
@@ -10,4 +10,5 @@ internal data class PingRequest(
     private val appVersion: String?,
     private val userIdentifiers: List<UserIdentifier>?,
     @SerializedName("supportedCampaignTypes") private val supportedTypes: List<Int>,
+    private val rmcSdkVersion: String?,
 )

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/ImpressionManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/ImpressionManager.kt
@@ -56,6 +56,7 @@ internal object ImpressionManager {
             sdkVersion = BuildConfig.VERSION_NAME,
             userIdentifiers = RuntimeUtil.getUserIdentifiers(),
             impressions = impListRequest,
+            rmcSdkVersion = HostAppInfoRepository.instance().getRmcSdkVersion(),
         )
 
         // Schedule work to report impressions back to IAM backend.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -165,7 +165,7 @@ internal class MessageReadinessManager(
             locale = hostAppInfoRepo.getDeviceLocale(),
             lastPingInMillis = campaignRepo.lastSyncMillis ?: 0,
             userIdentifier = RuntimeUtil.getUserIdentifiers(),
-            rmcSdkVersion = hostAppInfoRepo.getRmcSdkVersion()
+            rmcSdkVersion = hostAppInfoRepo.getRmcSdkVersion(),
         )
     }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/manager/MessageReadinessManager.kt
@@ -165,6 +165,7 @@ internal class MessageReadinessManager(
             locale = hostAppInfoRepo.getDeviceLocale(),
             lastPingInMillis = campaignRepo.lastSyncMillis ?: 0,
             userIdentifier = RuntimeUtil.getUserIdentifiers(),
+            rmcSdkVersion = hostAppInfoRepo.getRmcSdkVersion()
         )
     }
 

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Build
 import android.provider.Settings
 import androidx.core.content.pm.PackageInfoCompat
+import com.rakuten.tech.mobile.inappmessaging.runtime.RmcHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
@@ -78,6 +79,11 @@ internal object Initializer {
     }
 
     /**
+     * This method retrieves host app's RMC SDK version.
+     */
+    private fun getRmcSdkVersion(context: Context) = RmcHelper.getRmcVersion(context)
+
+    /**
      * This method retrieves host app's package name.
      */
     private fun getHostAppPackageName(context: Context): String =
@@ -95,6 +101,7 @@ internal object Initializer {
             packageName = getHostAppPackageName(context), deviceId = getDeviceId(context, sharedUtil),
             version = getHostAppVersion(context), subscriptionKey = subscriptionKey, locale = getLocale(context),
             configUrl = configUrl, isTooltipFeatureEnabled = enableTooltipFeature, context = context,
+            rmcSdkVersion = getRmcSdkVersion(context)
         )
 
         // Store hostAppInfo in repository.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/Initializer.kt
@@ -101,7 +101,7 @@ internal object Initializer {
             packageName = getHostAppPackageName(context), deviceId = getDeviceId(context, sharedUtil),
             version = getHostAppVersion(context), subscriptionKey = subscriptionKey, locale = getLocale(context),
             configUrl = configUrl, isTooltipFeatureEnabled = enableTooltipFeature, context = context,
-            rmcSdkVersion = getRmcSdkVersion(context)
+            rmcSdkVersion = getRmcSdkVersion(context),
         )
 
         // Store hostAppInfo in repository.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorker.kt
@@ -6,7 +6,6 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.rakuten.tech.mobile.inappmessaging.runtime.BuildConfig
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
-import com.rakuten.tech.mobile.inappmessaging.runtime.RmcHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.api.ConfigRetrofitService
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
@@ -79,7 +78,7 @@ internal class ConfigWorker(
             locale = hostRepo.getDeviceLocale(),
             appVersion = hostAppVersion,
             sdkVersion = BuildConfig.VERSION_NAME,
-            rmcSdkVersion = hostRepo.getRmcSdkVersion()
+            rmcSdkVersion = hostRepo.getRmcSdkVersion(),
         ).queryParams
         return RuntimeUtil.getRetrofit()
             .create(ConfigRetrofitService::class.java)

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.rakuten.tech.mobile.inappmessaging.runtime.BuildConfig
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.RmcHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.api.ConfigRetrofitService
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
@@ -73,19 +74,17 @@ internal class ConfigWorker(
     }
 
     private fun setupCall(hostAppId: String, hostAppVersion: String, subscriptionId: String): Call<ConfigResponse> {
-        val locale = hostRepo.getDeviceLocale()
-        val configUrl = hostRepo.getConfigUrl()
-        val sdkVersion = BuildConfig.VERSION_NAME
         val params = ConfigQueryParamsBuilder(
             appId = hostAppId,
-            locale = locale,
+            locale = hostRepo.getDeviceLocale(),
             appVersion = hostAppVersion,
-            sdkVersion = sdkVersion,
+            sdkVersion = BuildConfig.VERSION_NAME,
+            rmcSdkVersion = hostRepo.getRmcSdkVersion()
         ).queryParams
         return RuntimeUtil.getRetrofit()
             .create(ConfigRetrofitService::class.java)
             .getConfigService(
-                url = configUrl, subscriptionId = subscriptionId,
+                url = hostRepo.getConfigUrl(), subscriptionId = subscriptionId,
                 deviceId = hostRepo.getDeviceId(), parameters = params,
             )
     }

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
@@ -79,7 +79,7 @@ internal class MessageMixerWorker(
         // Create an pingRequest for the API.
         val pingRequest = PingRequest(
             HostAppInfoRepository.instance().getVersion(), RuntimeUtil.getUserIdentifiers(),
-            getSupportedCampaign(),
+            getSupportedCampaign(), HostAppInfoRepository.instance().getRmcSdkVersion()
         )
 
         // Create an retrofit API network call.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
@@ -79,7 +79,7 @@ internal class MessageMixerWorker(
         // Create an pingRequest for the API.
         val pingRequest = PingRequest(
             HostAppInfoRepository.instance().getVersion(), RuntimeUtil.getUserIdentifiers(),
-            getSupportedCampaign(), HostAppInfoRepository.instance().getRmcSdkVersion()
+            getSupportedCampaign(), HostAppInfoRepository.instance().getRmcSdkVersion(),
         )
 
         // Create an retrofit API network call.

--- a/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
+++ b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/MessageMixerWorker.kt
@@ -78,8 +78,10 @@ internal class MessageMixerWorker(
 
         // Create an pingRequest for the API.
         val pingRequest = PingRequest(
-            HostAppInfoRepository.instance().getVersion(), RuntimeUtil.getUserIdentifiers(),
-            getSupportedCampaign(), HostAppInfoRepository.instance().getRmcSdkVersion(),
+            appVersion = HostAppInfoRepository.instance().getVersion(),
+            userIdentifiers = RuntimeUtil.getUserIdentifiers(),
+            supportedTypes = getSupportedCampaign(),
+            rmcSdkVersion = HostAppInfoRepository.instance().getRmcSdkVersion(),
         )
 
         // Create an retrofit API network call.

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingTestConstants.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingTestConstants.kt
@@ -9,4 +9,5 @@ object InAppMessagingTestConstants {
     const val SUB_KEY = "12345-abcde"
     const val DEVICE_ID = "3a57f343769516eb"
     const val ACC = 1
+    const val RMC_VERSION = "1.0.0"
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/RmcHelperSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/RmcHelperSpec.kt
@@ -22,7 +22,7 @@ class RmcHelperSpec {
 
     @Test
     fun `isRmcIntegrated should return true`() {
-        `when`(mockContext.getString(anyInt())).thenReturn("1.0.0")
+        `when`(mockContext.getString(anyInt())).thenReturn(InAppMessagingTestConstants.RMC_VERSION)
 
         RmcHelper.isRmcIntegrated(mockContext) shouldBeEqualTo true
     }
@@ -36,9 +36,9 @@ class RmcHelperSpec {
 
     @Test
     fun `getRmcVersion should return version from resource`() {
-        `when`(mockContext.getString(anyInt())).thenReturn("1.0.0")
+        `when`(mockContext.getString(anyInt())).thenReturn(InAppMessagingTestConstants.RMC_VERSION)
 
-        RmcHelper.getRmcVersion(mockContext) shouldBeEqualTo "1.0.0"
+        RmcHelper.getRmcVersion(mockContext) shouldBeEqualTo InAppMessagingTestConstants.RMC_VERSION
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepositorySpec.kt
@@ -31,7 +31,7 @@ class HostAppInfoRepositorySpec : BaseTest() {
         InAppMessagingTestConstants.APP_VERSION, InAppMessagingTestConstants.SUB_KEY,
         InAppMessagingTestConstants.LOCALE, isTooltipFeatureEnabled = true,
         context = ApplicationProvider.getApplicationContext(),
-        rmcSdkVersion = InAppMessagingTestConstants.RMC_VERSION
+        rmcSdkVersion = InAppMessagingTestConstants.RMC_VERSION,
     )
 
     @Before

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepositorySpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/repositories/HostAppInfoRepositorySpec.kt
@@ -31,6 +31,7 @@ class HostAppInfoRepositorySpec : BaseTest() {
         InAppMessagingTestConstants.APP_VERSION, InAppMessagingTestConstants.SUB_KEY,
         InAppMessagingTestConstants.LOCALE, isTooltipFeatureEnabled = true,
         context = ApplicationProvider.getApplicationContext(),
+        rmcSdkVersion = InAppMessagingTestConstants.RMC_VERSION
     )
 
     @Before
@@ -57,6 +58,7 @@ class HostAppInfoRepositorySpec : BaseTest() {
             .getSubscriptionKey() shouldBeEqualTo InAppMessagingTestConstants.SUB_KEY
         HostAppInfoRepository.instance().getDeviceId() shouldBeEqualTo InAppMessagingTestConstants.DEVICE_ID
         HostAppInfoRepository.instance().getContext() shouldBeEqualTo ApplicationProvider.getApplicationContext()
+        HostAppInfoRepository.instance().getRmcSdkVersion() shouldBeEqualTo InAppMessagingTestConstants.RMC_VERSION
     }
 
     @Test
@@ -172,6 +174,7 @@ class HostAppInfoRepositorySpec : BaseTest() {
         instance.getSubscriptionKey().shouldBeEmpty()
         instance.getDeviceId().shouldBeEmpty()
         instance.getConfigUrl().shouldBeEmpty()
+        instance.getRmcSdkVersion().shouldBeNull()
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilderSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilderSpec.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.requests
 
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotHaveKey
 import org.junit.Test
 
@@ -15,7 +14,7 @@ class ConfigQueryParamsBuilderSpec {
             locale = "jp",
             appVersion = "0.0.1",
             sdkVersion = "1.6.0-SNAPSHOT",
-            rmcSdkVersion = "1.0.0"
+            rmcSdkVersion = "1.0.0",
         )
         testDataClass.apply {
             queryParams["platform"] shouldBeEqualTo InAppMessagingConstants.ANDROID_PLATFORM_ENUM

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilderSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ConfigQueryParamsBuilderSpec.kt
@@ -2,6 +2,8 @@ package com.rakuten.tech.mobile.inappmessaging.runtime.data.requests
 
 import com.rakuten.tech.mobile.inappmessaging.runtime.utils.InAppMessagingConstants
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotHaveKey
 import org.junit.Test
 
 class ConfigQueryParamsBuilderSpec {
@@ -13,6 +15,7 @@ class ConfigQueryParamsBuilderSpec {
             locale = "jp",
             appVersion = "0.0.1",
             sdkVersion = "1.6.0-SNAPSHOT",
+            rmcSdkVersion = "1.0.0"
         )
         testDataClass.apply {
             queryParams["platform"] shouldBeEqualTo InAppMessagingConstants.ANDROID_PLATFORM_ENUM
@@ -20,7 +23,14 @@ class ConfigQueryParamsBuilderSpec {
             queryParams["sdkVersion"] shouldBeEqualTo "1.6.0-SNAPSHOT"
             queryParams["appVersion"] shouldBeEqualTo "0.0.1"
             queryParams["locale"] shouldBeEqualTo "jp"
+            queryParams["rmcSdkVersion"] shouldBeEqualTo "1.0.0"
         }
+    }
+
+    @Test
+    fun `should not include rmcSdkVersion in queryParams when set to null`() {
+        val testDataClass = ConfigQueryParamsBuilder(rmcSdkVersion = null)
+        testDataClass.queryParams shouldNotHaveKey "rmcSdkVersion"
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequestSpec.kt
@@ -9,28 +9,44 @@ import org.junit.Test
 @OptIn(ExperimentalStdlibApi::class)
 class DisplayPermissionRequestSpec {
 
+    private val displayPermissionRequest = DisplayPermissionRequest(
+        campaignId = "test-campaignId",
+        appVersion = "test-appVersion",
+        sdkVersion = "test-sdkVersion",
+        locale = "test-locale",
+        lastPingInMillis = 0L,
+        userIdentifier = listOf(UserIdentifier(id = "test-id", type = 0)),
+        rmcSdkVersion = "1.0.0",
+    )
+
     @Test
     fun `should serialize DisplayPermissionRequest with correct json field names`() {
-        val testDataClass = DisplayPermissionRequest(
-            campaignId = "test-campaignId",
-            appVersion = "test-appVersion",
-            sdkVersion = "test-sdkVersion",
-            locale = "test-locale",
-            lastPingInMillis = 0L,
-            userIdentifier = listOf(UserIdentifier(id = "test-id", type = 0)),
-            rmcSdkVersion = null,
-        )
+        val json = """
+            >{"campaignId":"test-campaignId","appVersion":"test-appVersion","sdkVersion":"test-sdkVersion",
+            >"locale":"test-locale","lastPingInMillis":0,"userIdentifier":[{"id":"test-id","type":0}],
+            >"rmcSdkVersion":"1.0.0","platform":2}
+        """.trimMargin(">").replace("\n", "")
+
+        Gson().toJson(displayPermissionRequest) shouldBeEqualTo json
+    }
+
+    @Test
+    fun `should not serialize DisplayPermissionRequest with null values`() {
+        val testDataClass = displayPermissionRequest.copy(rmcSdkVersion = null)
+
         val json = """
             >{"campaignId":"test-campaignId","appVersion":"test-appVersion","sdkVersion":"test-sdkVersion",
             >"locale":"test-locale","lastPingInMillis":0,"userIdentifier":[{"id":"test-id","type":0}],"platform":2}
         """.trimMargin(">").replace("\n", "")
-        Gson().toJson(testDataClass).shouldBeEqualTo(json)
+
+        Gson().toJson(testDataClass) shouldBeEqualTo json
     }
 
     @Test
     fun `should deserialize DisplayPermissionRequest from json field names set`() {
         val json = """{"lastPingInMillis":0,"userIdentifier":[{"id":"test-id","type":0}],"platform":2}"""
         val testDataClass = Gson().fromJson(json, DisplayPermissionRequest::class.java)
+
         testDataClass.shouldBeEquivalentTo(
             DisplayPermissionRequest(
                 campaignId = null,

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/DisplayPermissionRequestSpec.kt
@@ -18,6 +18,7 @@ class DisplayPermissionRequestSpec {
             locale = "test-locale",
             lastPingInMillis = 0L,
             userIdentifier = listOf(UserIdentifier(id = "test-id", type = 0)),
+            rmcSdkVersion = null,
         )
         val json = """
             >{"campaignId":"test-campaignId","appVersion":"test-appVersion","sdkVersion":"test-sdkVersion",
@@ -38,6 +39,7 @@ class DisplayPermissionRequestSpec {
                 locale = null,
                 lastPingInMillis = 0,
                 userIdentifier = listOf(UserIdentifier(id = "test-id", type = 0)),
+                rmcSdkVersion = null,
             ),
         )
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequestSpec.kt
@@ -18,6 +18,7 @@ class ImpressionRequestSpec {
             sdkVersion = "test-sdkVersion",
             userIdentifiers = listOf(),
             impressions = listOf(Impression(ImpressionType.EXIT, 0)),
+            rmcSdkVersion = null,
         )
         val json = """
             >{"campaignId":"test-campaignId","isTest":false,"appVersion":"test-appVersion",
@@ -39,6 +40,7 @@ class ImpressionRequestSpec {
                 sdkVersion = null,
                 userIdentifiers = listOf(),
                 impressions = listOf(),
+                rmcSdkVersion = null,
             ),
         )
     }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequestSpec.kt
@@ -9,23 +9,37 @@ import org.junit.Test
 @OptIn(ExperimentalStdlibApi::class)
 class ImpressionRequestSpec {
 
+    private val impressionRequest = ImpressionRequest(
+        campaignId = "test-campaignId",
+        isTest = false,
+        appVersion = "test-appVersion",
+        sdkVersion = "test-sdkVersion",
+        userIdentifiers = listOf(),
+        impressions = listOf(Impression(ImpressionType.EXIT, 0)),
+        rmcSdkVersion = "1.0.0",
+    )
+
     @Test
     fun `should serialize ImpressionRequest with correct json field names`() {
-        val testDataClass = ImpressionRequest(
-            campaignId = "test-campaignId",
-            isTest = false,
-            appVersion = "test-appVersion",
-            sdkVersion = "test-sdkVersion",
-            userIdentifiers = listOf(),
-            impressions = listOf(Impression(ImpressionType.EXIT, 0)),
-            rmcSdkVersion = null,
-        )
+        val json = """
+            >{"campaignId":"test-campaignId","isTest":false,"appVersion":"test-appVersion",
+            >"sdkVersion":"test-sdkVersion","userIdentifiers":[],
+            >"impressions":[{"impType":"EXIT","timestamp":0,"type":4}],"rmcSdkVersion":"1.0.0"}
+        """.trimMargin(">").replace("\n", "")
+        Gson().toJson(impressionRequest) shouldBeEqualTo json
+    }
+
+    @Test
+    fun `should not serialize ImpressionRequest with null values`() {
+        val testDataClass = impressionRequest.copy(rmcSdkVersion = null)
         val json = """
             >{"campaignId":"test-campaignId","isTest":false,"appVersion":"test-appVersion",
             >"sdkVersion":"test-sdkVersion","userIdentifiers":[],
             >"impressions":[{"impType":"EXIT","timestamp":0,"type":4}]}
+            >
         """.trimMargin(">").replace("\n", "")
-        Gson().toJson(testDataClass).shouldBeEqualTo(json)
+
+        Gson().toJson(testDataClass) shouldBeEqualTo json
     }
 
     @Test

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/ImpressionRequestSpec.kt
@@ -36,7 +36,6 @@ class ImpressionRequestSpec {
             >{"campaignId":"test-campaignId","isTest":false,"appVersion":"test-appVersion",
             >"sdkVersion":"test-sdkVersion","userIdentifiers":[],
             >"impressions":[{"impType":"EXIT","timestamp":0,"type":4}]}
-            >
         """.trimMargin(">").replace("\n", "")
 
         Gson().toJson(testDataClass) shouldBeEqualTo json

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequestSpec.kt
@@ -13,6 +13,7 @@ class PingRequestSpec {
             appVersion = "appVersion",
             userIdentifiers = listOf(),
             supportedTypes = listOf(CampaignType.REGULAR.typeId),
+            rmcSdkVersion = null,
         )
         val json = """{"appVersion":"appVersion","userIdentifiers":[],"supportedCampaignTypes":[1]}"""
         Gson().toJson(testDataClass).shouldBeEqualTo(json)

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequestSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/data/requests/PingRequestSpec.kt
@@ -7,15 +7,27 @@ import org.junit.Test
 
 class PingRequestSpec {
 
+    private val pingRequest = PingRequest(
+        appVersion = "appVersion",
+        userIdentifiers = listOf(),
+        supportedTypes = listOf(CampaignType.REGULAR.typeId),
+        rmcSdkVersion = "1.0.0",
+    )
+
     @Test
     fun `should serialize PingRequest with correct json field names`() {
-        val testDataClass = PingRequest(
-            appVersion = "appVersion",
-            userIdentifiers = listOf(),
-            supportedTypes = listOf(CampaignType.REGULAR.typeId),
-            rmcSdkVersion = null,
-        )
+        val json = """
+            >{"appVersion":"appVersion","userIdentifiers":[],"supportedCampaignTypes":[1],"rmcSdkVersion":"1.0.0"}
+        """.trimMargin(">").replace("\n", "")
+
+        Gson().toJson(pingRequest) shouldBeEqualTo json
+    }
+
+    @Test
+    fun `should not serialize PingRequest with null values`() {
+        val testDataClass = pingRequest.copy(rmcSdkVersion = null)
         val json = """{"appVersion":"appVersion","userIdentifiers":[],"supportedCampaignTypes":[1]}"""
-        Gson().toJson(testDataClass).shouldBeEqualTo(json)
+
+        Gson().toJson(testDataClass) shouldBeEqualTo json
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -10,6 +10,7 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.InApp.AppManifestConfig
 import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.RmcHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
@@ -96,6 +97,17 @@ class InitializerSpec : BaseTest() {
         Initializer.initializeSdk(appCtx, "test", "")
 
         HostAppInfoRepository.instance().getDeviceId() shouldBeEqualTo "test_uuid"
+    }
+
+    @Test
+    fun `should set rmcSdkVersion`() {
+        Mockito.mockStatic(RmcHelper::class.java).use { mockHelper ->
+            mockHelper.`when`<Any> { RmcHelper.getRmcVersion(context) }.thenReturn("1.0.0")
+
+            Initializer.initializeSdk(context, "test", "")
+
+            HostAppInfoRepository.instance().getRmcSdkVersion() shouldBeEqualTo "1.0.0"
+        }
     }
 
     private fun verifyHostAppInfo() {

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -7,8 +7,12 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.Data
 import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
-import com.rakuten.tech.mobile.inappmessaging.runtime.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.InApp.AppManifestConfig
+import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessagingTestConstants
+import com.rakuten.tech.mobile.inappmessaging.runtime.RmcHelper
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.sdkutils.PreferencesUtil

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/utils/InitializerSpec.kt
@@ -7,11 +7,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.Data
 import androidx.work.WorkerParameters
 import androidx.work.testing.WorkManagerTestInitHelper
+import com.rakuten.tech.mobile.inappmessaging.runtime.*
 import com.rakuten.tech.mobile.inappmessaging.runtime.InApp.AppManifestConfig
-import com.rakuten.tech.mobile.inappmessaging.runtime.BaseTest
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
-import com.rakuten.tech.mobile.inappmessaging.runtime.RmcHelper
-import com.rakuten.tech.mobile.inappmessaging.runtime.TestUserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.HostAppInfoRepository
 import com.rakuten.tech.mobile.inappmessaging.runtime.exception.InAppMessagingException
 import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
@@ -102,11 +99,12 @@ class InitializerSpec : BaseTest() {
     @Test
     fun `should set rmcSdkVersion`() {
         Mockito.mockStatic(RmcHelper::class.java).use { mockHelper ->
-            mockHelper.`when`<Any> { RmcHelper.getRmcVersion(context) }.thenReturn("1.0.0")
+            mockHelper.`when`<Any> { RmcHelper.getRmcVersion(context) }
+                .thenReturn(InAppMessagingTestConstants.RMC_VERSION)
 
             Initializer.initializeSdk(context, "test", "")
 
-            HostAppInfoRepository.instance().getRmcSdkVersion() shouldBeEqualTo "1.0.0"
+            HostAppInfoRepository.instance().getRmcSdkVersion() shouldBeEqualTo InAppMessagingTestConstants.RMC_VERSION
         }
     }
 

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionSchedulerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/schedulers/ImpressionSchedulerSpec.kt
@@ -88,6 +88,7 @@ class ImpressionSchedulerSpec : BaseTest() {
             HostAppInfoRepository.instance().getVersion(),
             RuntimeUtil.getUserIdentifiers(),
             ImpressionManager.createImpressionList(impressionTypes),
+            null,
         )
         ImpressionScheduler().startImpressionWorker(impressionRequest, mockManager)
     }


### PR DESCRIPTION
# Description
* Added sending of `rmcSdkVersion`:
   - `/config` -> URL parameter
   - `/ping`, `/display_permission`, and `/impression` -> body

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
