### PR TITLE
improve: abort further processing/retries when config URL is empty (SDKCF-6736)

### DIFF
--- a/inappmessaging/USERGUIDE.md
+++ b/inappmessaging/USERGUIDE.md
@@ -501,6 +501,7 @@ Documents targeting Product Managers:
   - Dokka to `1.8.10`
   - Robolectric to `4.10.3`
   - Dependency Check to `8.2.1`
+* SDKCF-6736: Improved worker to abort further processing when config URL is empty.
 * SDKCF-6547: Fixed impression is not incremented when tooltip campaign is displayed.
 * SDKCF-6518: Fixed and suppressed some SonarCloud code smells.
 * Updates for RMC SDK:

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingTestConstants.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingTestConstants.kt
@@ -6,6 +6,7 @@ object InAppMessagingTestConstants {
     const val APP_ID = "com.rakuten.test"
     val LOCALE = Locale.getDefault()
     const val APP_VERSION = "0.0.1"
+    const val CONFIG_URL = "https://config"
     const val SUB_KEY = "12345-abcde"
     const val DEVICE_ID = "3a57f343769516eb"
     const val ACC = 1

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
@@ -51,8 +51,8 @@ class IntegrationSpec {
             context, workerParameters, HostAppInfoRepository.instance(),
             ConfigResponseRepository.instance(), mockMessageScheduler,
         )
-        val expected = if (HostAppInfoRepository.instance().getConfigUrl().isNullOrEmpty()) {
-            ListenableWorker.Result.retry()
+        val expected = if (HostAppInfoRepository.instance().getConfigUrl().isEmpty()) {
+            ListenableWorker.Result.failure()
         } else {
             ListenableWorker.Result.success()
         }
@@ -81,7 +81,7 @@ class IntegrationSpec {
             CampaignRepository.instance().lastSyncMillis?.shouldBeGreaterThan(0)
             CampaignRepository.instance().messages.shouldBeEmpty()
         } else {
-            result shouldBeEqualTo ListenableWorker.Result.retry()
+            result shouldBeEqualTo ListenableWorker.Result.failure()
         }
     }
 }

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
@@ -116,7 +116,12 @@ class ConfigWorkerSuccessSpec : ConfigWorkerSpec() {
         `when`(mockHostRepo.getConfigUrl()).thenReturn(bundle.getString(CONFIG_KEY, ""))
         `when`(mockHostRepo.getSubscriptionKey()).thenReturn(bundle.getString(SUB_KEY, ""))
         val worker = ConfigWorker(this.ctx, workParam, mockHostRepo, mockConfigRepo, mockMsgSched)
-        worker.doWork() shouldBeEqualTo ListenableWorker.Result.success()
+        val expected = if (bundle.getString(CONFIG_KEY, "").isNullOrEmpty()) {
+            ListenableWorker.Result.failure()
+        } else {
+            ListenableWorker.Result.success()
+        }
+        worker.doWork() shouldBeEqualTo expected
     }
 
 //    @Test


### PR DESCRIPTION
# Description
* Abort unnecessary processing when config URL is empty

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
