### PR TITLE
improve: save user details in sample app cache

### DIFF
--- a/test/src/main/java/com/rakuten/test/AppUserInfoProvider.kt
+++ b/test/src/main/java/com/rakuten/test/AppUserInfoProvider.kt
@@ -1,9 +1,7 @@
 package com.rakuten.test
 
 import android.content.Context
-import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
-import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.LoginSuccessfulEvent
 import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
 
 class AppUserInfoProvider(private val context: Context) : UserInfoProvider {
@@ -35,7 +33,6 @@ class AppUserInfoProvider(private val context: Context) : UserInfoProvider {
         PreferencesUtil.putString(context, SHARED_FILE, USER_ID, userId)
         PreferencesUtil.putString(context, SHARED_FILE, TOKEN_OR_ID_TRACKING, tokenOrIdTracking)
         PreferencesUtil.putBoolean(context, SHARED_FILE, IS_ID_TRACKING, isIdTracking)
-        InAppMessaging.instance().logEvent(LoginSuccessfulEvent())
     }
 
     companion object {

--- a/test/src/main/java/com/rakuten/test/AppUserInfoProvider.kt
+++ b/test/src/main/java/com/rakuten/test/AppUserInfoProvider.kt
@@ -1,16 +1,47 @@
 package com.rakuten.test
 
+import android.content.Context
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
+import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.appevents.LoginSuccessfulEvent
+import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
 
-class AppUserInfoProvider : UserInfoProvider {
-
-    var userId = ""
-    var accessToken = ""
-    var idTracking = ""
+class AppUserInfoProvider(private val context: Context) : UserInfoProvider {
     
-    override fun provideAccessToken() = accessToken
+    override fun provideAccessToken(): String {
+        if (!isIdTracking()) {
+            return PreferencesUtil.getString(context, SHARED_FILE, TOKEN_OR_ID_TRACKING, "").orEmpty()
+        }
+        return ""
+    }
 
-    override fun provideUserId() = userId
+    override fun provideUserId(): String {
+        return PreferencesUtil.getString(context, SHARED_FILE, USER_ID, "").orEmpty()
+    }
 
-    override fun provideIdTrackingIdentifier() = idTracking
+    override fun provideIdTrackingIdentifier(): String {
+        if (isIdTracking()) {
+            return PreferencesUtil.getString(context, SHARED_FILE, TOKEN_OR_ID_TRACKING, "").orEmpty()
+        }
+        return ""
+    }
+
+    fun isIdTracking(): Boolean {
+        return PreferencesUtil.getBoolean(context, SHARED_FILE, IS_ID_TRACKING, true)
+    }
+
+    fun saveUser(userId: String, tokenOrIdTracking: String, isIdTracking: Boolean) {
+        PreferencesUtil.clear(context, SHARED_FILE)
+        PreferencesUtil.putString(context, SHARED_FILE, USER_ID, userId)
+        PreferencesUtil.putString(context, SHARED_FILE, TOKEN_OR_ID_TRACKING, tokenOrIdTracking)
+        PreferencesUtil.putBoolean(context, SHARED_FILE, IS_ID_TRACKING, isIdTracking)
+        InAppMessaging.instance().logEvent(LoginSuccessfulEvent())
+    }
+
+    companion object {
+        private const val USER_ID: String = "user-id"
+        private const val SHARED_FILE: String = "user-shared-file"
+        private const val TOKEN_OR_ID_TRACKING: String = "token-or-id-tracking"
+        private const val IS_ID_TRACKING: String = "is-id-tracking"
+    }
 }

--- a/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
+++ b/test/src/main/java/com/rakuten/test/MainActivityFragment.kt
@@ -127,19 +127,17 @@ class MainActivityFragment : Fragment(), View.OnClickListener {
         tokenOrIdTrackingRadio.check(tokenOrIdTrackingRadio.getChildAt(if (isIdTracking) 0 else 1).id)
         val tokenOrIdTracking = contentView.findViewById<EditText>(R.id.edit_tokenOrTrackingId)
         tokenOrIdTracking.setText(
-            if (isIdTracking) appProvider.provideIdTrackingIdentifier()else appProvider.provideAccessToken())
+            if (isIdTracking) appProvider.provideIdTrackingIdentifier() else appProvider.provideAccessToken())
 
         val dialog =  AlertDialog.Builder(activity)
                 .setView(contentView)
                 .setTitle(R.string.dialog_title_user)
                 .setPositiveButton(android.R.string.ok) { dialog, _ ->
-                    if (appProvider.provideUserId() != userId.text.toString()) {
-                        InAppMessaging.instance().closeMessage()
-                    }
                     val tokenOrIdTrackingType = tokenOrIdTrackingRadio
                         .indexOfChild(tokenOrIdTrackingRadio.findViewById(tokenOrIdTrackingRadio.checkedRadioButtonId))
                     appProvider.saveUser(userId.text.toString(), tokenOrIdTracking.text.toString(),
                         tokenOrIdTrackingType == 0)
+                    InAppMessaging.instance().logEvent(LoginSuccessfulEvent())
                     dialog.dismiss()
                 }
                 .setNegativeButton(android.R.string.cancel) {dialog, _ ->

--- a/test/src/main/java/com/rakuten/test/MainApplication.kt
+++ b/test/src/main/java/com/rakuten/test/MainApplication.kt
@@ -5,7 +5,7 @@ import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
 
 class MainApplication : Application() {
 
-    val provider = AppUserInfoProvider()
+    val provider = AppUserInfoProvider(this)
     lateinit var settings: IAMSettings
 
     override fun onCreate() {

--- a/test/src/main/res/layout/fragment_main.xml
+++ b/test/src/main/res/layout/fragment_main.xml
@@ -79,7 +79,7 @@
     android:id="@+id/custom_event"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:text="@string/custom_event_newuser"/>
+    android:text="@string/custom_event"/>
 
   <Button
       android:id="@+id/reconfigure"

--- a/test/src/main/res/values/strings.xml
+++ b/test/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
   <string name="purchase_successful">Purchase Successful</string>
   <string name="purchase_successful_twice">Purchase Successful 2x</string>
   <string name="login_purchase_successful">Login and Purchase Successful</string>
-  <string name="custom_event_newuser">Custom Event: newUser</string>
+  <string name="custom_event">Custom Event</string>
   <string name="change_user">Change User</string>
   <string name="label_userid">User ID</string>
   <string name="label_tokenOrTrackingID">Tracking ID/\nAccess Token</string>


### PR DESCRIPTION
# Description
* For testing app relaunches
* Previously this was implemented in `onDestroy` but it isn't guaranteed to be called
