### PR TITLE
improve: save config settings in sample app cache (SDKCF-6887)

### DIFF
--- a/test/src/main/java/com/rakuten/test/IAMSettings.kt
+++ b/test/src/main/java/com/rakuten/test/IAMSettings.kt
@@ -2,18 +2,54 @@ package com.rakuten.test
 
 import android.content.Context
 import android.content.pm.PackageManager
+import com.rakuten.tech.mobile.sdkutils.PreferencesUtil
 
-class IAMSettings(context: Context) {
-
-    var subscriptionKey: String
-    var configUrl: String
-    var isTooltipFeatureEnabled: Boolean = true
+class IAMSettings(private val context: Context) {
 
     init {
+        setDefaults()
+    }
+
+    fun getConfigUrl(): String {
+        return PreferencesUtil.getString(context, SHARED_FILE, CONFIG_URL, "").orEmpty()
+    }
+
+    fun getSubscriptionKey(): String {
+        return PreferencesUtil.getString(context, SHARED_FILE, SUBSCRIPTION_KEY, "").orEmpty()
+    }
+
+    fun isTooltipEnabled(): Boolean {
+        return PreferencesUtil.getBoolean(context, SHARED_FILE, IS_TOOLTIP_ENABLED, true)
+    }
+
+    fun saveConfig(configUrl: String, subscriptionKey: String, isTooltipEnabled: Boolean) {
+        PreferencesUtil.clear(context, SHARED_FILE)
+        PreferencesUtil.putString(context, SHARED_FILE, CONFIG_URL, configUrl)
+        PreferencesUtil.putString(context, SHARED_FILE, SUBSCRIPTION_KEY, subscriptionKey)
+        PreferencesUtil.putBoolean(context, SHARED_FILE, IS_TOOLTIP_ENABLED, isTooltipEnabled)
+    }
+
+    private fun setDefaults() {
         val metadata =
             context.packageManager.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA).metaData
 
-        subscriptionKey = metadata.getString("com.rakuten.tech.mobile.inappmessaging.subscriptionkey") ?: ""
-        configUrl = metadata.getString("com.rakuten.tech.mobile.inappmessaging.configurl") ?: ""
+        var configUrl = getConfigUrl()
+        if (configUrl.isEmpty()) {
+            configUrl = metadata.getString("com.rakuten.tech.mobile.inappmessaging.configurl").orEmpty()
+        }
+
+        var subscriptionKey = getSubscriptionKey()
+        if (subscriptionKey.isEmpty()) {
+            subscriptionKey = metadata.getString("com.rakuten.tech.mobile.inappmessaging.subscriptionkey").orEmpty()
+        }
+
+        saveConfig(configUrl, subscriptionKey, isTooltipEnabled())
+    }
+
+    companion object {
+        private const val SHARED_FILE = "iam-config"
+        private const val CONFIG_URL = "config-url"
+        private const val SUBSCRIPTION_KEY = "subscription-key"
+        private const val IS_TOOLTIP_ENABLED = "is-tooltip-enabled"
     }
 }

--- a/test/src/main/java/com/rakuten/test/MainApplication.kt
+++ b/test/src/main/java/com/rakuten/test/MainApplication.kt
@@ -11,7 +11,12 @@ class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         settings = IAMSettings(this)
-        InAppMessaging.configure(this, enableTooltipFeature = settings.isTooltipFeatureEnabled)
+        InAppMessaging.configure(
+            context = this,
+            subscriptionKey = settings.getSubscriptionKey(),
+            configUrl = settings.getConfigUrl(),
+            enableTooltipFeature = settings.isTooltipEnabled()
+        )
         InAppMessaging.instance().registerPreference(provider)
     }
 }

--- a/test/src/main/java/com/rakuten/test/MainFragment.kt
+++ b/test/src/main/java/com/rakuten/test/MainFragment.kt
@@ -150,22 +150,24 @@ class MainFragment : Fragment(), View.OnClickListener {
         val settings = (activity?.application as MainApplication).settings
 
         val configUrl = contentView.findViewById<EditText>(R.id.edit_config_url)
-        configUrl.setText(settings.configUrl)
+        configUrl.setText(settings.getConfigUrl())
         val subsKey = contentView.findViewById<EditText>(R.id.edit_subs_key)
-        subsKey.setText(settings.subscriptionKey)
+        subsKey.setText(settings.getSubscriptionKey())
         val enableTooltip = contentView.findViewById<SwitchCompat>(R.id.tooltip_feat_switch)
-        enableTooltip.isChecked = settings.isTooltipFeatureEnabled
+        enableTooltip.isChecked = settings.isTooltipEnabled()
 
         val dialog =  AlertDialog.Builder(activity)
             .setView(contentView)
             .setTitle(R.string.label_reconfigure)
             .setPositiveButton(android.R.string.ok) { dialog, _ ->
                 context?.let {
-                    settings.subscriptionKey = subsKey.text.toString()
-                    settings.configUrl = configUrl.text.toString()
-                    settings.isTooltipFeatureEnabled = enableTooltip.isChecked
-                    InAppMessaging.configure(it, settings.subscriptionKey, settings.configUrl,
-                        enableTooltipFeature = settings.isTooltipFeatureEnabled)
+                    settings.saveConfig(
+                        configUrl = configUrl.text.toString(),
+                        subscriptionKey = subsKey.text.toString(),
+                        isTooltipEnabled = enableTooltip.isChecked
+                    )
+                    InAppMessaging.configure(it, settings.getSubscriptionKey(), settings.getConfigUrl(),
+                        enableTooltipFeature = settings.isTooltipEnabled())
                 }
                 dialog.dismiss()
             }


### PR DESCRIPTION
# Description
For testing app relaunches with runtime configuration (sample app update only)

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
