### PR TITLE
test: fix failing tests due to appId and subsKey mismatch

### DIFF
--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingTestConstants.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/InAppMessagingTestConstants.kt
@@ -3,7 +3,7 @@ package com.rakuten.tech.mobile.inappmessaging.runtime
 import java.util.Locale
 
 object InAppMessagingTestConstants {
-    const val APP_ID = "com.rakuten.test"
+    const val APP_ID = "rakuten.com.tech.mobile.test"
     val LOCALE = Locale.getDefault()
     const val APP_VERSION = "0.0.1"
     const val CONFIG_URL = "https://config"

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
@@ -7,6 +7,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.rakuten.tech.mobile.inappmessaging.runtime.InApp.AppManifestConfig
 import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessaging
+import com.rakuten.tech.mobile.inappmessaging.runtime.InAppMessagingTestConstants
 import com.rakuten.tech.mobile.inappmessaging.runtime.UserInfoProvider
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.models.HostAppInfo
 import com.rakuten.tech.mobile.inappmessaging.runtime.data.repositories.ConfigResponseRepository
@@ -94,7 +95,7 @@ class IntegrationSpec {
         HostAppInfoRepository.instance().apply {
             addHostInfo(
                 HostAppInfo(
-                    packageName = "rakuten.com.tech.mobile.test",
+                    packageName = InAppMessagingTestConstants.APP_ID,
                     deviceId = this.getDeviceId(),
                     version = this.getVersion(),
                     subscriptionKey = this.getSubscriptionKey(),

--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/workmanager/workers/ConfigWorkerSpec.kt
@@ -67,7 +67,7 @@ open class ConfigWorkerSpec : BaseTest() {
 
     internal fun initializeInstance() {
         val testAppInfo = HostAppInfo(
-            "rakuten.com.tech.mobile.test",
+            InAppMessagingTestConstants.APP_ID,
             InAppMessagingTestConstants.DEVICE_ID, InAppMessagingTestConstants.APP_VERSION,
             "test-key", InAppMessagingTestConstants.LOCALE,
         )
@@ -110,7 +110,6 @@ class ConfigWorkerSuccessSpec : ConfigWorkerSpec() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
         val app = ctx.packageManager.getApplicationInfo(ctx.packageName, PackageManager.GET_META_DATA)
         val bundle = app.metaData
-        `when`(mockHostRepo.getPackageName()).thenReturn(ctx.packageName)
         val version = ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName
         `when`(mockHostRepo.getVersion()).thenReturn(version)
         `when`(mockHostRepo.getConfigUrl()).thenReturn(bundle.getString(CONFIG_KEY, ""))


### PR DESCRIPTION
# Description
Backend will now throw error code 400 if appId & subsKey does not match

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [ ] I added ticket/changes in changelog
- [x] I ran `./gradlew check` without errors
