### PR TITLE
test: fix integration test failure

### DIFF
--- a/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
+++ b/inappmessaging/src/test/java/com/rakuten/tech/mobile/inappmessaging/runtime/integration/IntegrationSpec.kt
@@ -80,7 +80,6 @@ class IntegrationSpec {
             val pingWorker = MessageMixerWorker(context, workerParameters, mockEventScheduler, mockMessageScheduler)
             pingWorker.doWork() shouldBeEqualTo ListenableWorker.Result.success()
             CampaignRepository.instance().lastSyncMillis?.shouldBeGreaterThan(0)
-            CampaignRepository.instance().messages.shouldBeEmpty()
         } else {
             result shouldBeEqualTo ListenableWorker.Result.failure()
         }


### PR DESCRIPTION
# Description
`should return valid ping response` test is failing because it validates whether campaign list is empty.
It does not make sense to check it, since campaign list can or cannot have value as it's controlled remotely.
Returning worker success is enough for this test.
